### PR TITLE
Support checkbox control

### DIFF
--- a/ember-headless-form/src/components/-private/control/checkbox.hbs
+++ b/ember-headless-form/src/components/-private/control/checkbox.hbs
@@ -1,0 +1,7 @@
+<input
+  type='checkbox'
+  checked={{@value}}
+  id={{@fieldId}}
+  ...attributes
+  {{on 'click' this.handleInput}}
+/>

--- a/ember-headless-form/src/components/-private/control/checkbox.ts
+++ b/ember-headless-form/src/components/-private/control/checkbox.ts
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 
 export interface HeadlessFormControlCheckboxComponentSignature {

--- a/ember-headless-form/src/components/-private/control/checkbox.ts
+++ b/ember-headless-form/src/components/-private/control/checkbox.ts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+
+export interface HeadlessFormControlCheckboxComponentSignature {
+  Element: HTMLInputElement;
+  Args: {
+    value: boolean;
+    fieldId: string;
+    setValue: (value: boolean) => void;
+  };
+}
+
+export default class HeadlessFormControlCheckboxComponent extends Component<HeadlessFormControlCheckboxComponentSignature> {
+  @action
+  handleInput(e: Event | InputEvent): void {
+    this.args.setValue((e.target as HTMLInputElement).checked);
+  }
+}

--- a/ember-headless-form/src/components/-private/control/input.hbs
+++ b/ember-headless-form/src/components/-private/control/input.hbs
@@ -1,6 +1,6 @@
 <input
   type={{@type}}
-  value={{this.valueAsString}}
+  value={{@value}}
   id={{@fieldId}}
   ...attributes
   {{on 'input' this.handleInput}}

--- a/ember-headless-form/src/components/-private/control/input.ts
+++ b/ember-headless-form/src/components/-private/control/input.ts
@@ -59,6 +59,7 @@ export default class HeadlessFormControlInputComponent extends Component<Headles
 
   @action
   handleInput(e: Event | InputEvent): void {
-    this.args.setValue((e.target as HTMLInputElement).value);
+    assert('Expected HTMLInputElement', e.target instanceof HTMLInputElement);
+    this.args.setValue(e.target.value);
   }
 }

--- a/ember-headless-form/src/components/-private/control/input.ts
+++ b/ember-headless-form/src/components/-private/control/input.ts
@@ -28,22 +28,20 @@ export type InputType =
   | 'url'
   | 'week';
 
-export interface HeadlessFormControlInputComponentSignature<VALUE> {
+export interface HeadlessFormControlInputComponentSignature {
   Element: HTMLInputElement;
   Args: {
-    value: VALUE;
+    value: string;
     type?: InputType;
     fieldId: string;
-    setValue: (value: VALUE) => void;
+    setValue: (value: string) => void;
   };
 }
 
-export default class HeadlessFormControlInputComponent<VALUE> extends Component<
-  HeadlessFormControlInputComponentSignature<VALUE>
-> {
+export default class HeadlessFormControlInputComponent extends Component<HeadlessFormControlInputComponentSignature> {
   constructor(
     owner: unknown,
-    args: HeadlessFormControlInputComponentSignature<VALUE>['Args']
+    args: HeadlessFormControlInputComponentSignature['Args']
   ) {
     assert(
       `input component does not support @type="${args.type}" as there is a dedicated component for this. Please use the \`field.${args.type}\` instead!`,
@@ -59,18 +57,8 @@ export default class HeadlessFormControlInputComponent<VALUE> extends Component<
     return this.args.type ?? 'text';
   }
 
-  get valueAsString(): string {
-    assert(
-      `input can only handle string values, but you passed ${typeof this.args
-        .value}`,
-      typeof this.args.value === 'string'
-    );
-
-    return this.args.value;
-  }
-
   @action
   handleInput(e: Event | InputEvent): void {
-    this.args.setValue((e.target as HTMLInputElement).value as VALUE);
+    this.args.setValue((e.target as HTMLInputElement).value);
   }
 }

--- a/ember-headless-form/src/components/-private/control/input.ts
+++ b/ember-headless-form/src/components/-private/control/input.ts
@@ -41,6 +41,20 @@ export interface HeadlessFormControlInputComponentSignature<VALUE> {
 export default class HeadlessFormControlInputComponent<VALUE> extends Component<
   HeadlessFormControlInputComponentSignature<VALUE>
 > {
+  constructor(
+    owner: unknown,
+    args: HeadlessFormControlInputComponentSignature<VALUE>['Args']
+  ) {
+    assert(
+      `input component does not support @type="${args.type}" as there is a dedicated component for this. Please use the \`field.${args.type}\` instead!`,
+      args.type === undefined ||
+        // TS would guard us against using an unsupported `InputType`, but for JS consumers we add a dev-only runtime check here
+        (args.type as string) !== 'checkbox'
+    );
+
+    super(owner, args);
+  }
+
   get type(): InputType {
     return this.args.type ?? 'text';
   }

--- a/ember-headless-form/src/components/-private/field.hbs
+++ b/ember-headless-form/src/components/-private/field.hbs
@@ -8,6 +8,12 @@
         value=this.value
         setValue=setValue
       )
+      checkbox=(component
+        (ensure-safe-component this.CheckboxComponent)
+        fieldId=uuid
+        value=this.value
+        setValue=setValue
+      )
       value=this.value
       id=uuid
       setValue=setValue

--- a/ember-headless-form/src/components/-private/field.hbs
+++ b/ember-headless-form/src/components/-private/field.hbs
@@ -5,14 +5,14 @@
       input=(component
         (ensure-safe-component this.InputComponent)
         fieldId=uuid
-        value=this.value
-        setValue=setValue
+        value=this.valueAsString
+        setValue=this.setValue
       )
       checkbox=(component
         (ensure-safe-component this.CheckboxComponent)
         fieldId=uuid
-        value=this.value
-        setValue=setValue
+        value=this.valueAsBoolean
+        setValue=this.setValue
       )
       value=this.value
       id=uuid

--- a/ember-headless-form/src/components/-private/field.ts
+++ b/ember-headless-form/src/components/-private/field.ts
@@ -1,16 +1,16 @@
 import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
 
-import InputComponent from './control/input';
 import CheckboxComponent from './control/checkbox';
+import InputComponent from './control/input';
 import LabelComponent from './field/label';
 
 import type { HeadlessFormData } from '../headless-form';
-import type { HeadlessFormControlInputComponentSignature } from './control/input';
 import type { HeadlessFormControlCheckboxComponentSignature } from './control/checkbox';
+import type { HeadlessFormControlInputComponentSignature } from './control/input';
 import type { HeadlessFormFieldLabelComponentSignature } from './field/label';
 import type { ComponentLike, WithBoundArgs } from '@glint/template';
-import { assert } from '@ember/debug';
-import { action } from '@ember/object';
 
 export interface HeadlessFormFieldComponentSignature<
   DATA extends HeadlessFormData,

--- a/ember-headless-form/src/components/-private/field.ts
+++ b/ember-headless-form/src/components/-private/field.ts
@@ -9,6 +9,8 @@ import type { HeadlessFormControlInputComponentSignature } from './control/input
 import type { HeadlessFormControlCheckboxComponentSignature } from './control/checkbox';
 import type { HeadlessFormFieldLabelComponentSignature } from './field/label';
 import type { ComponentLike, WithBoundArgs } from '@glint/template';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
 
 export interface HeadlessFormFieldComponentSignature<
   DATA extends HeadlessFormData,
@@ -24,7 +26,7 @@ export interface HeadlessFormFieldComponentSignature<
       {
         label: WithBoundArgs<typeof LabelComponent, 'fieldId'>;
         input: WithBoundArgs<
-          typeof InputComponent<DATA[KEY]>,
+          typeof InputComponent,
           'fieldId' | 'value' | 'setValue'
         >;
         checkbox: WithBoundArgs<
@@ -45,13 +47,39 @@ export default class HeadlessFormFieldComponent<
 > extends Component<HeadlessFormFieldComponentSignature<DATA, KEY>> {
   LabelComponent: ComponentLike<HeadlessFormFieldLabelComponentSignature> =
     LabelComponent;
-  InputComponent: ComponentLike<
-    HeadlessFormControlInputComponentSignature<DATA[KEY]>
-  > = InputComponent;
+  InputComponent: ComponentLike<HeadlessFormControlInputComponentSignature> =
+    InputComponent;
   CheckboxComponent: ComponentLike<HeadlessFormControlCheckboxComponentSignature> =
     CheckboxComponent;
 
   get value(): DATA[KEY] {
     return this.args.data[this.args.name];
+  }
+
+  get valueAsString(): string {
+    assert(
+      `Only string values are expected for ${String(
+        this.args.name
+      )}, but you passed ${typeof this.value}`,
+      typeof this.value === 'string'
+    );
+
+    return this.value;
+  }
+
+  get valueAsBoolean(): boolean {
+    assert(
+      `Only boolean values are expected for ${String(
+        this.args.name
+      )}, but you passed ${typeof this.value}`,
+      typeof this.value === 'boolean'
+    );
+
+    return this.value;
+  }
+
+  @action
+  setValue(value: unknown): void {
+    this.args.set(this.args.name, value as DATA[KEY]);
   }
 }

--- a/ember-headless-form/src/components/-private/field.ts
+++ b/ember-headless-form/src/components/-private/field.ts
@@ -1,16 +1,14 @@
 import Component from '@glimmer/component';
 
 import InputComponent from './control/input';
+import CheckboxComponent from './control/checkbox';
 import LabelComponent from './field/label';
 
 import type { HeadlessFormData } from '../headless-form';
-import type {
-  HeadlessFormControlInputComponentSignature,
-} from './control/input';
-import type {
-  HeadlessFormFieldLabelComponentSignature,
-} from './field/label';
-import type { ComponentLike,WithBoundArgs } from '@glint/template';
+import type { HeadlessFormControlInputComponentSignature } from './control/input';
+import type { HeadlessFormControlCheckboxComponentSignature } from './control/checkbox';
+import type { HeadlessFormFieldLabelComponentSignature } from './field/label';
+import type { ComponentLike, WithBoundArgs } from '@glint/template';
 
 export interface HeadlessFormFieldComponentSignature<
   DATA extends HeadlessFormData,
@@ -27,6 +25,10 @@ export interface HeadlessFormFieldComponentSignature<
         label: WithBoundArgs<typeof LabelComponent, 'fieldId'>;
         input: WithBoundArgs<
           typeof InputComponent<DATA[KEY]>,
+          'fieldId' | 'value' | 'setValue'
+        >;
+        checkbox: WithBoundArgs<
+          typeof CheckboxComponent,
           'fieldId' | 'value' | 'setValue'
         >;
         value: DATA[KEY];
@@ -46,6 +48,8 @@ export default class HeadlessFormFieldComponent<
   InputComponent: ComponentLike<
     HeadlessFormControlInputComponentSignature<DATA[KEY]>
   > = InputComponent;
+  CheckboxComponent: ComponentLike<HeadlessFormControlCheckboxComponentSignature> =
+    CheckboxComponent;
 
   get value(): DATA[KEY] {
     return this.args.data[this.args.name];

--- a/ember-headless-form/src/components/-private/field.ts
+++ b/ember-headless-form/src/components/-private/field.ts
@@ -56,23 +56,23 @@ export default class HeadlessFormFieldComponent<
     return this.args.data[this.args.name];
   }
 
-  get valueAsString(): string {
+  get valueAsString(): string | undefined {
     assert(
       `Only string values are expected for ${String(
         this.args.name
       )}, but you passed ${typeof this.value}`,
-      typeof this.value === 'string'
+      typeof this.value === 'undefined' || typeof this.value === 'string'
     );
 
     return this.value;
   }
 
-  get valueAsBoolean(): boolean {
+  get valueAsBoolean(): boolean | undefined {
     assert(
       `Only boolean values are expected for ${String(
         this.args.name
       )}, but you passed ${typeof this.value}`,
-      typeof this.value === 'boolean'
+      typeof this.value === 'undefined' || typeof this.value === 'boolean'
     );
 
     return this.value;

--- a/test-app/tests/integration/components/headless-form-test.gts
+++ b/test-app/tests/integration/components/headless-form-test.gts
@@ -230,6 +230,24 @@ module('Integration Component headless-form', function (hooks) {
         assert.dom('input').hasAttribute('type', type, `supports type=${type}`);
       }
     });
+
+    // Unfortunately this test does not work due to `render` throwing in a deferred way (not covered by its returned promise)
+    // See https://github.com/emberjs/ember-test-helpers/issues/310
+    // keeping this still here to capture the intended behaviour (which works!), and for Glint type checking
+    skip('input throws for type handled by dedicated component', async function (assert) {
+      const data = { checked: false };
+
+      assert.rejects(
+        render(<template>
+          <HeadlessForm @data={{data}} as |form|>
+            <form.field @name="checked" as |field|>
+              {{! @glint-expect-error }}
+              <field.input @type="checkbox" />
+            </form.field>
+          </HeadlessForm>
+        </template>)
+      );
+    });
   });
 
   module('field.checkbox', function () {

--- a/test-app/tests/integration/components/headless-form-test.gts
+++ b/test-app/tests/integration/components/headless-form-test.gts
@@ -399,7 +399,7 @@ module('Integration Component headless-form', function (hooks) {
         assert.deepEqual(
           data,
           { firstName: 'Tony', lastName: 'Ward', acceptTerms: false },
-          'data is not mutated'
+          'original data is not mutated'
         );
 
         assert.true(
@@ -455,13 +455,14 @@ module('Integration Component headless-form', function (hooks) {
 
     test('@name argument only expects keys of @data', async function (assert) {
       assert.expect(0);
+      // Note that we have only firstName here in the type that is passed to @data, no lastName!
       const data = { firstName: 'Simon' };
 
       await render(<template>
         <HeadlessForm @data={{data}} as |form|>
           {{! this is valid }}
           <form.field @name="firstName" />
-          {{! @glint-expect-error this is expected to be a glint error! }}
+          {{! @glint-expect-error this is expected to be a glint error, as "lastName" does not exist on the type of @data! }}
           <form.field @name="lastName" />
         </HeadlessForm>
       </template>);
@@ -475,7 +476,7 @@ module('Integration Component headless-form', function (hooks) {
         <HeadlessForm @data={{data}} as |form|>
           {{! this is valid }}
           <form.field @name="firstName" />
-          {{! @glint-expect-error this is expected to be a glint error! }}
+          {{! @glint-expect-error this is expected to be a glint error, as "lastName" does not exist on the type of @data! }}
           <form.field @name="lastName" />
         </HeadlessForm>
       </template>);
@@ -487,7 +488,7 @@ module('Integration Component headless-form', function (hooks) {
 
       await render(<template>
         <HeadlessForm @data={{data}} as |form|>
-          {{! @glint-expect-error this is expected to be a glint error! }}
+          {{! @glint-expect-error this is expected to be a glint error, as "lastName" does not exist on the type of @data! }}
           <form.field @name="firstName" />
         </HeadlessForm>
       </template>);

--- a/test-app/tests/integration/components/headless-form-test.gts
+++ b/test-app/tests/integration/components/headless-form-test.gts
@@ -72,53 +72,6 @@ module('Integration Component headless-form', function (hooks) {
 
       assert.strictEqual(id, inputId, "yielded ID matches input's id");
     });
-
-    module('Glint', function () {
-      // These tests are not testing any new run-time behaviour that isn't tested elsewhere already.
-      // Rather they are here to make sure they pass glint checks, testing for their types constraints to work as expected
-      // Note: @glint-expect-error behaves just as @ts-expect-error in that in surpresses an error when we *expect* it to error,
-      // but it *also* fails when no expected error is actually present!
-
-      test('@name argument only expects keys of @data', async function (assert) {
-        assert.expect(0);
-        const data = { firstName: 'Simon' };
-
-        await render(<template>
-          <HeadlessForm @data={{data}} as |form|>
-            {{! this is valid }}
-            <form.field @name="firstName" />
-            {{! @glint-expect-error this is expected to be a glint error! }}
-            <form.field @name="lastName" />
-          </HeadlessForm>
-        </template>);
-      });
-
-      test('@name argument only expects keys of @data w/ partial data', async function (assert) {
-        assert.expect(0);
-        const data: { firstName?: string } = {};
-
-        await render(<template>
-          <HeadlessForm @data={{data}} as |form|>
-            {{! this is valid }}
-            <form.field @name="firstName" />
-            {{! @glint-expect-error this is expected to be a glint error! }}
-            <form.field @name="lastName" />
-          </HeadlessForm>
-        </template>);
-      });
-
-      test('@name argument w/ an untyped @data errors', async function (assert) {
-        assert.expect(0);
-        const data = {};
-
-        await render(<template>
-          <HeadlessForm @data={{data}} as |form|>
-            {{! @glint-expect-error this is expected to be a glint error! }}
-            <form.field @name="firstName" />
-          </HeadlessForm>
-        </template>);
-      });
-    });
   });
 
   module('field.label', function () {
@@ -177,7 +130,7 @@ module('Integration Component headless-form', function (hooks) {
 
   module('field.input', function () {
     test('field yields input component', async function (assert) {
-      const data = { firstName: 'Simon' };
+      const data: { firstName?: string } = {};
 
       await render(<template>
         <HeadlessForm @data={{data}} as |form|>
@@ -252,7 +205,7 @@ module('Integration Component headless-form', function (hooks) {
 
   module('field.checkbox', function () {
     test('field yields checkbox component', async function (assert) {
-      const data = { checked: false };
+      const data: { checked?: boolean } = {};
 
       await render(<template>
         <HeadlessForm @data={{data}} as |form|>
@@ -486,6 +439,81 @@ module('Integration Component headless-form', function (hooks) {
 
         assert.dom('input[data-test-first-name]').hasValue('Nicole');
       });
+    });
+  });
+
+  module('Glint', function () {
+    // These tests are not testing any new run-time behaviour that isn't tested elsewhere already.
+    // Rather they are here to make sure they pass glint checks, testing for their types constraints to work as expected
+    // Note: @glint-expect-error behaves just as @ts-expect-error in that in surpresses an error when we *expect* it to error,
+    // but it *also* fails when no expected error is actually present!
+
+    test('@name argument only expects keys of @data', async function (assert) {
+      assert.expect(0);
+      const data = { firstName: 'Simon' };
+
+      await render(<template>
+        <HeadlessForm @data={{data}} as |form|>
+          {{! this is valid }}
+          <form.field @name="firstName" />
+          {{! @glint-expect-error this is expected to be a glint error! }}
+          <form.field @name="lastName" />
+        </HeadlessForm>
+      </template>);
+    });
+
+    test('@name argument only expects keys of @data w/ partial data', async function (assert) {
+      assert.expect(0);
+      const data: { firstName?: string } = {};
+
+      await render(<template>
+        <HeadlessForm @data={{data}} as |form|>
+          {{! this is valid }}
+          <form.field @name="firstName" />
+          {{! @glint-expect-error this is expected to be a glint error! }}
+          <form.field @name="lastName" />
+        </HeadlessForm>
+      </template>);
+    });
+
+    test('@name argument w/ an untyped @data errors', async function (assert) {
+      assert.expect(0);
+      const data = {};
+
+      await render(<template>
+        <HeadlessForm @data={{data}} as |form|>
+          {{! @glint-expect-error this is expected to be a glint error! }}
+          <form.field @name="firstName" />
+        </HeadlessForm>
+      </template>);
+    });
+
+    test('field.input can only be used for string values', async function (assert) {
+      assert.expect(0);
+      const data: { prop?: boolean } = {};
+
+      await render(<template>
+        <HeadlessForm @data={{data}} as |form|>
+          {{! @glint-expect-error }}
+          <form.field @name="prop" as |field|>
+            <field.input />
+          </form.field>
+        </HeadlessForm>
+      </template>);
+    });
+
+    test('field.checkbox can only be used for boolean values', async function (assert) {
+      assert.expect(0);
+      const data: { prop?: string } = {};
+
+      await render(<template>
+        <HeadlessForm @data={{data}} as |form|>
+          {{! @glint-expect-error }}
+          <form.field @name="prop" as |field|>
+            <field.checkbox />
+          </form.field>
+        </HeadlessForm>
+      </template>);
     });
   });
 });

--- a/test-app/tests/integration/components/headless-form-test.gts
+++ b/test-app/tests/integration/components/headless-form-test.gts
@@ -487,33 +487,5 @@ module('Integration Component headless-form', function (hooks) {
         </HeadlessForm>
       </template>);
     });
-
-    test('field.input can only be used for string values', async function (assert) {
-      assert.expect(0);
-      const data: { prop?: boolean } = {};
-
-      await render(<template>
-        <HeadlessForm @data={{data}} as |form|>
-          {{! @glint-expect-error }}
-          <form.field @name="prop" as |field|>
-            <field.input />
-          </form.field>
-        </HeadlessForm>
-      </template>);
-    });
-
-    test('field.checkbox can only be used for boolean values', async function (assert) {
-      assert.expect(0);
-      const data: { prop?: string } = {};
-
-      await render(<template>
-        <HeadlessForm @data={{data}} as |form|>
-          {{! @glint-expect-error }}
-          <form.field @name="prop" as |field|>
-            <field.checkbox />
-          </form.field>
-        </HeadlessForm>
-      </template>);
-    });
   });
 });

--- a/test-app/tests/integration/components/headless-form-test.gts
+++ b/test-app/tests/integration/components/headless-form-test.gts
@@ -10,6 +10,7 @@ import {
   render,
   rerender,
   triggerEvent,
+  setupOnerror,
 } from '@ember/test-helpers';
 import { module, skip, test } from 'qunit';
 
@@ -184,22 +185,26 @@ module('Integration Component headless-form', function (hooks) {
       }
     });
 
-    // Unfortunately this test does not work due to `render` throwing in a deferred way (not covered by its returned promise)
-    // See https://github.com/emberjs/ember-test-helpers/issues/310
-    // keeping this still here to capture the intended behaviour (which works!), and for Glint type checking
-    skip('input throws for type handled by dedicated component', async function (assert) {
+    test('input throws for type handled by dedicated component', async function (assert) {
+      assert.expect(1);
+      setupOnerror((e: Error) => {
+        assert.strictEqual(
+          e.message,
+          'Assertion Failed: input component does not support @type="checkbox" as there is a dedicated component for this. Please use the `field.checkbox` instead!',
+          'Expected assertion error message'
+        );
+      });
+
       const data = { checked: false };
 
-      assert.rejects(
-        render(<template>
-          <HeadlessForm @data={{data}} as |form|>
-            <form.field @name="checked" as |field|>
-              {{! @glint-expect-error }}
-              <field.input @type="checkbox" />
-            </form.field>
-          </HeadlessForm>
-        </template>)
-      );
+      await render(<template>
+        <HeadlessForm @data={{data}} as |form|>
+          <form.field @name="checked" as |field|>
+            {{! @glint-expect-error }}
+            <field.input @type="checkbox" />
+          </form.field>
+        </HeadlessForm>
+      </template>);
     });
   });
 


### PR DESCRIPTION
Besides adding `field.checkbox`, this refactors a bit the internal types, related to passing only the suitable value type to a control: `field.input` should only handle `string` values, while `field.checkbox` is for `boolean`s.

Closes #8 

- [x] Blocked on merging #14 first!