### PR TITLE
Support `@validateOn="blur/change"`

### DIFF
--- a/ember-headless-form/package.json
+++ b/ember-headless-form/package.json
@@ -57,6 +57,7 @@
     "@types/ember__debug": "^4.0.0",
     "@types/ember__engine": "^4.0.0",
     "@types/ember__error": "^4.0.0",
+    "@types/ember__modifier": "^4.0.3",
     "@types/ember__object": "^4.0.0",
     "@types/ember__polyfills": "^4.0.0",
     "@types/ember__routing": "^4.0.0",

--- a/ember-headless-form/src/components/-private/types.ts
+++ b/ember-headless-form/src/components/-private/types.ts
@@ -55,7 +55,7 @@ export type FieldValidateCallback<
  * Internal structure to track used fields
  * @private
  */
-export interface FieldData<
+export interface FieldRegistrationData<
   DATA extends FormData,
   KEY extends FormKey<DATA> = FormKey<DATA>
 > {
@@ -69,7 +69,7 @@ export interface FieldData<
 export type RegisterFieldCallback<
   DATA extends FormData,
   KEY extends FormKey<DATA> = FormKey<DATA>
-> = (name: KEY, field: FieldData<DATA, KEY>) => void;
+> = (name: KEY, field: FieldRegistrationData<DATA, KEY>) => void;
 
 export type UnregisterFieldCallback<
   DATA extends FormData,
@@ -79,6 +79,4 @@ export type UnregisterFieldCallback<
 /**
  * Mapper type to construct subset of objects, whose keys are only strings (and not number or symbol)
  */
-export type OnlyStringKeys<T extends object> = {
-  [P in Extract<keyof T, string>]: T[P];
-};
+export type OnlyStringKeys<T extends object> = Pick<T, keyof T & string>;

--- a/ember-headless-form/src/components/headless-form.hbs
+++ b/ember-headless-form/src/components/headless-form.hbs
@@ -1,11 +1,18 @@
-<form ...attributes {{on 'submit' this.onSubmit}}>
+{{! ignoring prettier here is need to *not* wrap the modifier usage below into a new line, making @glint-expect-error fail to work 🙈 }}
+{{! prettier-ignore }}
+<form
+  ...attributes
+  {{on 'submit' this.onSubmit}}
+  {{! @glint-expect-error: modifier helper not supported, see https://github.com/typed-ember/glint/issues/410 }}
+  {{(if this.fieldValidationEvent (modifier this.on this.fieldValidationEvent this.handleFieldValidation))}}
+>
   {{yield
     (hash
       field=(component
         (ensure-safe-component this.FieldComponent)
         data=this.internalData
         set=this.set
-        errors=this.lastValidationResult
+        errors=this.visibleErrors
         registerField=this.registerField
         unregisterField=this.unregisterField
       )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,7 @@ importers:
       '@types/ember__debug': ^4.0.0
       '@types/ember__engine': ^4.0.0
       '@types/ember__error': ^4.0.0
+      '@types/ember__modifier': ^4.0.3
       '@types/ember__object': ^4.0.0
       '@types/ember__polyfills': ^4.0.0
       '@types/ember__routing': ^4.0.0
@@ -90,6 +91,7 @@ importers:
       '@types/ember__debug': 4.0.3_@babel+core@7.20.12
       '@types/ember__engine': 4.0.4_@babel+core@7.20.12
       '@types/ember__error': 4.0.2
+      '@types/ember__modifier': 4.0.3_@babel+core@7.20.12
       '@types/ember__object': 4.0.5_@babel+core@7.20.12
       '@types/ember__polyfills': 4.0.1
       '@types/ember__routing': 4.0.12_@babel+core@7.20.12
@@ -2975,10 +2977,7 @@ packages:
   /@types/ember__controller/4.0.4:
     resolution: {integrity: sha512-+f0knTIJJkRX5xijeSI/n4FvLfhMFFxIxODyFFFFB483EryYuts3QzpTwU5D66WQ5rAbZvpPRXRMPTTCNJoUhg==}
     dependencies:
-      '@types/ember__object': 4.0.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
+      '@types/ember__object': 4.0.5_@babel+core@7.20.12
     dev: true
 
   /@types/ember__controller/4.0.4_@babel+core@7.20.12:
@@ -3051,14 +3050,21 @@ packages:
       - supports-color
     dev: true
 
-  /@types/ember__object/4.0.5:
-    resolution: {integrity: sha512-gXrywWBwoW7J9y9yJqoZ0m1qtiyMdrEi29cJdF1xI2qOnMqaZeuSCMYaPQMsyq52/YnVIG2EnGzo6eUD57J4Nw==}
+  /@types/ember__modifier/4.0.3_@babel+core@7.20.12:
+    resolution: {integrity: sha512-2Z4ty8OZNVO/UkypnVMoqdp57OxRd48dko3wYzYMbjhR7Wi2Gtd374dLlhoA6WXcWnEyrz7SUCot8zyBpBZwfg==}
     dependencies:
-      '@types/ember': 4.0.3
-      '@types/rsvp': 4.0.4
+      '@types/ember': 4.0.3_@babel+core@7.20.12
+      '@types/ember__owner': 4.0.3
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+    dev: true
+
+  /@types/ember__object/4.0.5:
+    resolution: {integrity: sha512-gXrywWBwoW7J9y9yJqoZ0m1qtiyMdrEi29cJdF1xI2qOnMqaZeuSCMYaPQMsyq52/YnVIG2EnGzo6eUD57J4Nw==}
+    dependencies:
+      '@types/ember': 4.0.3_@babel+core@7.20.12
+      '@types/rsvp': 4.0.4
     dev: true
 
   /@types/ember__object/4.0.5_@babel+core@7.20.12:

--- a/test-app/app/templates/index.hbs
+++ b/test-app/app/templates/index.hbs
@@ -1,4 +1,9 @@
-<HeadlessForm @data={{this.data}} @onSubmit={{this.doSomething}} as |form|>
+<HeadlessForm
+  @data={{this.data}}
+  @validateOn='blur'
+  @onSubmit={{this.doSomething}}
+  as |form|
+>
   <form.field @name='name' as |field|>
     <field.label>Name</field.label>
     <field.input />

--- a/test-app/tests/integration/components/headless-form-validation-test.gts
+++ b/test-app/tests/integration/components/headless-form-validation-test.gts
@@ -846,146 +846,264 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
     );
   });
 
-  module('@validateOn="blur"', function () {
-    test('form validation callback is called on blur', async function (assert) {
-      const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
-      const validateCallback = sinon.spy();
+  module(`@validateOn`, function () {
+    module('blur', function () {
+      test('form validation callback is called on blur', async function (assert) {
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
+        const validateCallback = sinon.spy();
 
-      await render(<template>
-        <HeadlessForm
-          @data={{data}}
-          @validateOn="blur"
-          @validate={{validateCallback}}
-          as |form|
-        >
-          <form.field @name="firstName" as |field|>
-            <field.label>First Name</field.label>
-            <field.input data-test-first-name />
-          </form.field>
-          <form.field @name="lastName" as |field|>
-            <field.label>Last Name</field.label>
-            <field.input data-test-last-name />
-          </form.field>
-          <button type="submit" data-test-submit>Submit</button>
-        </HeadlessForm>
-      </template>);
-
-      await fillIn('[data-test-first-name]', 'Foo');
-
-      assert.false(
-        validateCallback.called,
-        '@validate is not called while typing'
-      );
-
-      await blur('[data-test-first-name]');
-
-      assert.true(
-        validateCallback.calledWith({ ...data, firstName: 'Foo' }),
-        '@validate is called with form data'
-      );
-    });
-
-    test('field validation callback is called on blur', async function (assert) {
-      const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
-      const validateCallback = sinon.spy();
-
-      await render(<template>
-        <HeadlessForm @data={{data}} @validateOn="blur" as |form|>
-          <form.field
-            @name="firstName"
+        await render(<template>
+          <HeadlessForm
+            @data={{data}}
+            @validateOn="blur"
             @validate={{validateCallback}}
-            as |field|
+            as |form|
           >
-            <field.label>First Name</field.label>
-            <field.input data-test-first-name />
-          </form.field>
-          <form.field @name="lastName" as |field|>
-            <field.label>Last Name</field.label>
-            <field.input data-test-last-name />
-          </form.field>
-          <button type="submit" data-test-submit>Submit</button>
-        </HeadlessForm>
-      </template>);
+            <form.field @name="firstName" as |field|>
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
 
-      await fillIn('[data-test-first-name]', 'Foo');
+        await fillIn('[data-test-first-name]', 'Foo');
 
-      assert.false(
-        validateCallback.called,
-        '@validate is not called while typing'
-      );
+        assert.false(
+          validateCallback.called,
+          '@validate is not called while typing'
+        );
 
-      await blur('[data-test-first-name]');
+        await blur('[data-test-first-name]');
 
-      assert.true(
-        validateCallback.calledWith('Foo', 'firstName', {
-          ...data,
-          firstName: 'Foo',
-        }),
-        '@validate is called with form data'
-      );
+        assert.true(
+          validateCallback.calledWith({ ...data, firstName: 'Foo' }),
+          '@validate is called with form data'
+        );
+      });
+
+      test('field validation callback is called on blur', async function (assert) {
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
+        const validateCallback = sinon.spy();
+
+        await render(<template>
+          <HeadlessForm @data={{data}} @validateOn="blur" as |form|>
+            <form.field
+              @name="firstName"
+              @validate={{validateCallback}}
+              as |field|
+            >
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
+
+        await fillIn('[data-test-first-name]', 'Foo');
+
+        assert.false(
+          validateCallback.called,
+          '@validate is not called while typing'
+        );
+
+        await blur('[data-test-first-name]');
+
+        assert.true(
+          validateCallback.calledWith('Foo', 'firstName', {
+            ...data,
+            firstName: 'Foo',
+          }),
+          '@validate is called with form data'
+        );
+      });
+
+      test('validation errors are exposed as field.errors on blur', async function (assert) {
+        const data: TestFormData = { firstName: 'Foo', lastName: 'Foo' };
+
+        await render(<template>
+          <HeadlessForm
+            @data={{data}}
+            @validateOn="blur"
+            @validate={{validateFormCallbackSync}}
+            as |form|
+          >
+            <form.field @name="firstName" as |field|>
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+              <field.errors data-test-first-name-errors />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+              <field.errors data-test-last-name-errors />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before validation happens'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before validation happens'
+          );
+
+        await fillIn('[data-test-first-name]', 'Foo');
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before validation happens'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before validation happens'
+          );
+
+        await blur('[data-test-first-name]');
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .exists(
+            { count: 1 },
+            'validation errors appear on blur when validation fails'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered for untouched fields'
+          );
+      });
     });
 
-    test('validation errors are exposed as field.errors on blur', async function (assert) {
-      const data: TestFormData = { firstName: 'Foo', lastName: 'Foo' };
+    module('change', function () {
+      test('form validation callback is called on change', async function (assert) {
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
+        const validateCallback = sinon.spy();
 
-      await render(<template>
-        <HeadlessForm
-          @data={{data}}
-          @validateOn="blur"
-          @validate={{validateFormCallbackSync}}
-          as |form|
-        >
-          <form.field @name="firstName" as |field|>
-            <field.label>First Name</field.label>
-            <field.input data-test-first-name />
-            <field.errors data-test-first-name-errors />
-          </form.field>
-          <form.field @name="lastName" as |field|>
-            <field.label>Last Name</field.label>
-            <field.input data-test-last-name />
-            <field.errors data-test-last-name-errors />
-          </form.field>
-          <button type="submit" data-test-submit>Submit</button>
-        </HeadlessForm>
-      </template>);
+        await render(<template>
+          <HeadlessForm
+            @data={{data}}
+            @validateOn="change"
+            @validate={{validateCallback}}
+            as |form|
+          >
+            <form.field @name="firstName" as |field|>
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
 
-      assert
-        .dom('[data-test-first-name-errors]')
-        .doesNotExist(
-          'validation errors are not rendered before validation happens'
-        );
-      assert
-        .dom('[data-test-last-name-errors]')
-        .doesNotExist(
-          'validation errors are not rendered before validation happens'
-        );
+        await fillIn('[data-test-first-name]', 'Foo');
 
-      await fillIn('[data-test-first-name]', 'Foo');
+        assert.true(
+          validateCallback.calledWith({ ...data, firstName: 'Foo' }),
+          '@validate is called with form data'
+        );
+      });
 
-      assert
-        .dom('[data-test-first-name-errors]')
-        .doesNotExist(
-          'validation errors are not rendered before validation happens'
-        );
-      assert
-        .dom('[data-test-last-name-errors]')
-        .doesNotExist(
-          'validation errors are not rendered before validation happens'
-        );
+      test('field validation callback is called on change', async function (assert) {
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
+        const validateCallback = sinon.spy();
 
-      await blur('[data-test-first-name]');
+        await render(<template>
+          <HeadlessForm @data={{data}} @validateOn="change" as |form|>
+            <form.field
+              @name="firstName"
+              @validate={{validateCallback}}
+              as |field|
+            >
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
 
-      assert
-        .dom('[data-test-first-name-errors]')
-        .exists(
-          { count: 1 },
-          'validation errors appear on blur when validation fails'
+        await fillIn('[data-test-first-name]', 'Foo');
+
+        assert.true(
+          validateCallback.calledWith('Foo', 'firstName', {
+            ...data,
+            firstName: 'Foo',
+          }),
+          '@validate is called with form data'
         );
-      assert
-        .dom('[data-test-last-name-errors]')
-        .doesNotExist(
-          'validation errors are not rendered for untouched fields'
-        );
+      });
+
+      test('validation errors are exposed as field.errors on change', async function (assert) {
+        const data: TestFormData = { firstName: 'Foo', lastName: 'Foo' };
+
+        await render(<template>
+          <HeadlessForm
+            @data={{data}}
+            @validateOn="change"
+            @validate={{validateFormCallbackSync}}
+            as |form|
+          >
+            <form.field @name="firstName" as |field|>
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+              <field.errors data-test-first-name-errors />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+              <field.errors data-test-last-name-errors />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before validation happens'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before validation happens'
+          );
+
+        await fillIn('[data-test-first-name]', 'Foo');
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .exists(
+            { count: 1 },
+            'validation errors appear on blur when validation fails'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered for untouched fields'
+          );
+      });
     });
   });
 });


### PR DESCRIPTION
This is a draft PR to just start a discussion, will close it afterwards as it is _not_ ready for review yet...

Let's say we have `@validateOn="blur"`. Now on an input (or other field control) the user causes the `blur`/`focusout` events to trigger. The action that must follow is that we validate, all fields or just this one, but most importantly we only _show_ the field's errors that triggered the event, not any other. 

So the question is this: how do we know, which field caused the event? There are several ways to do this, all with their pro and cons:

1. we can let the event bubble up to `<form>` (so our main `<HeadlessForm>` component), inspect the event target's `name` attribute (which is what we passed as `form.field @name="..."`) and use that to look-up the field. This. is what this PR currently does, and it works so far. However it requires the event to be triggered from a real native form control, and it needs to have `name` properly set up. That's the case here, but this might not work everywhere, e.g. might not work for rich custom controls like a `<PowerSelect>`, or combined controls like a date picker that (internally) is split up into 3 `<select>` with `name="date_{day,month,year}"`, so the `name` won't match what the field's name is (just `date` in this example). I think it would be possible to provide a yielded action like `triggerValidationFor(name)`, but this requires actively wiring this up for the user.
2. we could _only_ do the latter, i.e. provide a `triggerValidationFor(name)` and all controls need to wire this up explicitly, so our own here (`field.input`, `field.checkbox` etc.) same as any custom ones., and not rely on any `name` matching logic at all
3. or we could make our `form.field` component create a wrapper div, and attach the event listeners to that. Currently it does not render any markup (truly headless), so when the event bubbles up from the `<input>` it would immediately reach the `<form>`, at which point we wouldn't know which field this belongs to (unless we do 1.). But with a wrapping div (which would have `...attributes`, so users could use it for their own styling etc.) we would be able to catch the event within the boundaries of the field, so we _know_ which field this event belongs to, and show validation only for this field. This has the downside of an additional wrapping div, that does not have any other good reason to exist like a11y or so, so not really headless in a pure way. But the upside is that this would work out of the box, both for our own controls, but also any custom ones, as long as they are able to trigger `focusout`/`change` events properly.

Any thoughts?
