### PR TITLE
Support for `@validateOn`/`@revalidateOn` options

### DIFF
--- a/ember-headless-form/package.json
+++ b/ember-headless-form/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@babel/runtime": "^7.20.7",
     "@embroider/addon-shim": "^1.0.0",
+    "@ember/test-waiters": "^3.0.2",
     "@embroider/util": "^1.9.0",
     "tracked-built-ins": "^3.1.0"
   },

--- a/ember-headless-form/package.json
+++ b/ember-headless-form/package.json
@@ -57,6 +57,7 @@
     "@types/ember__debug": "^4.0.0",
     "@types/ember__engine": "^4.0.0",
     "@types/ember__error": "^4.0.0",
+    "@types/ember__modifier": "^4.0.3",
     "@types/ember__object": "^4.0.0",
     "@types/ember__polyfills": "^4.0.0",
     "@types/ember__routing": "^4.0.0",

--- a/ember-headless-form/src/components/-private/types.ts
+++ b/ember-headless-form/src/components/-private/types.ts
@@ -55,7 +55,7 @@ export type FieldValidateCallback<
  * Internal structure to track used fields
  * @private
  */
-export interface FieldData<
+export interface FieldRegistrationData<
   DATA extends FormData,
   KEY extends FormKey<DATA> = FormKey<DATA>
 > {
@@ -69,7 +69,7 @@ export interface FieldData<
 export type RegisterFieldCallback<
   DATA extends FormData,
   KEY extends FormKey<DATA> = FormKey<DATA>
-> = (name: KEY, field: FieldData<DATA, KEY>) => void;
+> = (name: KEY, field: FieldRegistrationData<DATA, KEY>) => void;
 
 export type UnregisterFieldCallback<
   DATA extends FormData,
@@ -79,6 +79,4 @@ export type UnregisterFieldCallback<
 /**
  * Mapper type to construct subset of objects, whose keys are only strings (and not number or symbol)
  */
-export type OnlyStringKeys<T extends object> = {
-  [P in Extract<keyof T, string>]: T[P];
-};
+export type OnlyStringKeys<T extends object> = Pick<T, keyof T & string>;

--- a/ember-headless-form/src/components/headless-form.hbs
+++ b/ember-headless-form/src/components/headless-form.hbs
@@ -1,11 +1,18 @@
-<form ...attributes {{on 'submit' this.onSubmit}}>
+{{! ignoring prettier here is need to *not* wrap the modifier usage below into a new line, making @glint-expect-error fail to work 🙈 }}
+{{! prettier-ignore }}
+<form
+  ...attributes
+  {{on 'submit' this.onSubmit}}
+  {{! @glint-expect-error: modifier helper not supported, see https://github.com/typed-ember/glint/issues/410 }}
+  {{(if this.fieldValidationEvent (modifier this.on this.fieldValidationEvent this.handleFieldValidation))}}
+>
   {{yield
     (hash
       field=(component
         (ensure-safe-component this.FieldComponent)
         data=this.internalData
         set=this.set
-        errors=this.lastValidationResult
+        errors=this.visibleErrors
         registerField=this.registerField
         unregisterField=this.unregisterField
       )

--- a/ember-headless-form/src/components/headless-form.hbs
+++ b/ember-headless-form/src/components/headless-form.hbs
@@ -5,6 +5,8 @@
   {{on 'submit' this.onSubmit}}
   {{! @glint-expect-error: modifier helper not supported, see https://github.com/typed-ember/glint/issues/410 }}
   {{(if this.fieldValidationEvent (modifier this.on this.fieldValidationEvent this.handleFieldValidation))}}
+  {{! @glint-expect-error: modifier helper not supported, see https://github.com/typed-ember/glint/issues/410 }}
+  {{(if this.fieldRevalidationEvent (modifier this.on this.fieldRevalidationEvent this.handleFieldRevalidation))}}
 >
   {{yield
     (hash

--- a/ember-headless-form/src/components/headless-form.ts
+++ b/ember-headless-form/src/components/headless-form.ts
@@ -89,18 +89,26 @@ export default class HeadlessFormComponent<
     const { validateOn } = this;
 
     return validateOn === 'submit'
-      ? undefined
-      : validateOn === 'blur'
+      ? // no need for dynamic validation, as validation always happens on submit
+        undefined
+      : // our component API expects "blur", but the actual blur event does not bubble up, so we use focusout internally instead
+      validateOn === 'blur'
       ? 'focusout'
       : validateOn;
   }
 
   get fieldRevalidationEvent(): 'focusout' | 'change' | undefined {
-    const { revalidateOn } = this;
+    const { validateOn, revalidateOn } = this;
 
     return revalidateOn === 'submit'
+      ? // no need for dynamic validation, as validation always happens on submit
+        undefined
+      : // when validation happens more frequently than revalidation, then we can ignore revalidation, because the validation handler will already cover us
+      validateOn === 'change' ||
+        (validateOn === 'blur' && revalidateOn === 'blur')
       ? undefined
-      : revalidateOn === 'blur'
+      : // our component API expects "blur", but the actual blur event does not bubble up, so we use focusout internally instead
+      revalidateOn === 'blur'
       ? 'focusout'
       : revalidateOn;
   }

--- a/ember-headless-form/src/components/headless-form.ts
+++ b/ember-headless-form/src/components/headless-form.ts
@@ -48,6 +48,9 @@ export interface HeadlessFormComponentSignature<DATA extends UserData> {
   };
 }
 
+/**
+ * This internal data structure maintains information about each field that is registered to the form by `registerField`.
+ */
 class FieldData<
   DATA extends FormData,
   KEY extends FormKey<DATA> = FormKey<DATA>
@@ -56,8 +59,14 @@ class FieldData<
     this.validate = fieldRegistration.validate;
   }
 
+  /**
+   * tracked state that enabled a dynamic validation of a field *before* the whole form is submitted, e.g. by `@validateOn="blur" and the blur event being triggered for that particular field.
+   */
   @tracked validationEnabled = false;
 
+  /**
+   * The *field* level validation callback passed to the field as in `<form.field @name="foo" @validate={{this.validateCallback}}>`
+   */
   validate?: FieldValidateCallback<DATA, KEY>;
 }
 
@@ -70,11 +79,21 @@ export default class HeadlessFormComponent<
   // we cannot use (modifier "on") directly in the template due to https://github.com/emberjs/ember.js/issues/19869
   on = on;
 
+  /**
+   * A copy of the passed `@data` stored internally, which is only passed back to the component consumer after a (successful) form submission.
+   */
   internalData: DATA = new TrackedObject(this.args.data ?? {}) as DATA;
 
   fields = new Map<FormKey<FormData<DATA>>, FieldData<FormData<DATA>>>();
 
+  /**
+   * The last result of calling `this.validate()`.
+   */
   @tracked lastValidationResult?: ErrorRecord<FormData<DATA>>;
+
+  /**
+   * When this is set to true by submitting the form, eventual validation errors are show for *all* field, regardless of their individual dynamic validation status in `FieldData#validationEnabled`
+   */
   @tracked showAllValidations = false;
 
   get validateOn(): ValidateOn {
@@ -85,6 +104,9 @@ export default class HeadlessFormComponent<
     return this.args.revalidateOn ?? 'change';
   }
 
+  /**
+   * Return the event type that will be listened on for dynamic validation (i.e. *before* submitting)
+   */
   get fieldValidationEvent(): 'focusout' | 'change' | undefined {
     const { validateOn } = this;
 
@@ -97,6 +119,9 @@ export default class HeadlessFormComponent<
       : validateOn;
   }
 
+  /**
+   * Return the event type that will be listened on for dynamic *re*validation, i.e. updating the validation status of a field that has been previously marked as invalid
+   */
   get fieldRevalidationEvent(): 'focusout' | 'change' | undefined {
     const { validateOn, revalidateOn } = this;
 
@@ -113,6 +138,9 @@ export default class HeadlessFormComponent<
       : revalidateOn;
   }
 
+  /**
+   * Return true if validation has happened (by submitting or by an `@validateOn` event being triggered) and at least one field is invalid
+   */
   get hasValidationErrors(): boolean {
     // Only consider validation errors for which we actually have a field rendered
     return this.lastValidationResult
@@ -122,6 +150,9 @@ export default class HeadlessFormComponent<
       : false;
   }
 
+  /**
+   * Call the passed validation callbacks, defined both on the whole form as well as on field level, and return the merged result for all fields.
+   */
   async validate(): Promise<ErrorRecord<FormData<DATA>> | undefined> {
     let errors: ErrorRecord<FormData<DATA>> | undefined = undefined;
 
@@ -152,6 +183,11 @@ export default class HeadlessFormComponent<
     return Object.keys(errors).length > 0 ? errors : undefined;
   }
 
+  /**
+   * Return a mapping of field to validation errors, for all fields that are invalid *and* for which validation errors should be visible.
+   * Validation errors will be visible for a certain field, if validation errors for *all* fields are visible, which is the case when trying to submit the form,
+   * or when that field has triggered the event given by `@validateOn` for showing validation errors before submitting, e.g. on blur.
+   */
   get visibleErrors(): ErrorRecord<FormData<DATA>> | undefined {
     if (!this.lastValidationResult) {
       return undefined;
@@ -171,6 +207,9 @@ export default class HeadlessFormComponent<
     return visibleErrors;
   }
 
+  /**
+   * Given a field name, return if eventual errors for the field should be visible. See `visibleErrors` for further details.
+   */
   showErrorsFor(field: FormKey<FormData<DATA>>): boolean {
     return (
       this.showAllValidations ||
@@ -220,6 +259,11 @@ export default class HeadlessFormComponent<
     this.internalData[key] = value;
   }
 
+  /**
+   * Handle the `@validateOn` event for a certain field, e.g. "blur".
+   * Associating the event with a field is done by looking at the event target's `name` attribute, which must match one of the `<form.field @name="...">` invocations by the user's template.
+   * Validation will be triggered, and the particular field will be marked to show eventual validation errors.
+   */
   @action
   async handleFieldValidation(e: Event): Promise<void> {
     const { target } = e;
@@ -237,6 +281,13 @@ export default class HeadlessFormComponent<
     }
   }
 
+  /**
+   * Handle the `@revalidateOn` event for a certain field, e.g. "blur".
+   * Associating the event with a field is done by looking at the event target's `name` attribute, which must match one of the `<form.field @name="...">` invocations by the user's template.
+   * When a field has been already marked to show validation errors by `@validateOn`, then for revalidation another validation will be triggered.
+   *
+   * The use case here is to allow this to happen more frequently than the initial validation, e.g. `@validateOn="blur" @revalidateOn="change"`.
+   */
   @action
   async handleFieldRevalidation(e: Event): Promise<void> {
     const { target } = e;
@@ -245,7 +296,6 @@ export default class HeadlessFormComponent<
     if (name) {
       if (this.showErrorsFor(name as FormKey<FormData<DATA>>)) {
         this.lastValidationResult = await this.validate();
-        // field.validationEnabled = true;
       }
     } else {
       // @todo how to handle custom controls that don't emit focusout/change events from native form controls?

--- a/ember-headless-form/src/components/headless-form.ts
+++ b/ember-headless-form/src/components/headless-form.ts
@@ -3,6 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { waitFor } from '@ember/test-waiters';
 
 import { TrackedObject } from 'tracked-built-ins';
 
@@ -153,6 +154,7 @@ export default class HeadlessFormComponent<
   /**
    * Call the passed validation callbacks, defined both on the whole form as well as on field level, and return the merged result for all fields.
    */
+  @waitFor
   async validate(): Promise<ErrorRecord<FormData<DATA>> | undefined> {
     let errors: ErrorRecord<FormData<DATA>> | undefined = undefined;
 

--- a/ember-headless-form/src/components/headless-form.ts
+++ b/ember-headless-form/src/components/headless-form.ts
@@ -95,6 +95,16 @@ export default class HeadlessFormComponent<
       : validateOn;
   }
 
+  get fieldRevalidationEvent(): 'focusout' | 'change' | undefined {
+    const { revalidateOn } = this;
+
+    return revalidateOn === 'submit'
+      ? undefined
+      : revalidateOn === 'blur'
+      ? 'focusout'
+      : revalidateOn;
+  }
+
   get hasValidationErrors(): boolean {
     // Only consider validation errors for which we actually have a field rendered
     return this.lastValidationResult
@@ -213,6 +223,21 @@ export default class HeadlessFormComponent<
       if (field) {
         this.lastValidationResult = await this.validate();
         field.validationEnabled = true;
+      }
+    } else {
+      // @todo how to handle custom controls that don't emit focusout/change events from native form controls?
+    }
+  }
+
+  @action
+  async handleFieldRevalidation(e: Event): Promise<void> {
+    const { target } = e;
+    const { name } = target as HTMLInputElement;
+
+    if (name) {
+      if (this.showErrorsFor(name as FormKey<FormData<DATA>>)) {
+        this.lastValidationResult = await this.validate();
+        // field.validationEnabled = true;
       }
     } else {
       // @todo how to handle custom controls that don't emit focusout/change events from native form controls?

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,7 @@ importers:
       '@babel/plugin-syntax-decorators': ^7.17.0
       '@babel/preset-typescript': ^7.18.6
       '@babel/runtime': ^7.20.7
+      '@ember/test-waiters': ^3.0.2
       '@embroider/addon-dev': ^3.0.0
       '@embroider/addon-shim': ^1.0.0
       '@embroider/util': ^1.9.0
@@ -66,6 +67,7 @@ importers:
       typescript: ^4.7.4
     dependencies:
       '@babel/runtime': 7.20.7
+      '@ember/test-waiters': 3.0.2
       '@embroider/addon-shim': 1.8.4
       '@embroider/util': 1.9.0
       tracked-built-ins: 3.1.0
@@ -2044,7 +2046,6 @@ packages:
       semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@embroider/addon-dev/3.0.0_rollup@2.79.1:
     resolution: {integrity: sha512-h3ISDdp8LASA6583WC3IU3ECZ5fHlW3V3EkgpEeeH7KhxTerHjDjNf+S6+ZvPH+ZHi3WOCYPvUA5OfNICyMbtA==}
@@ -2977,7 +2978,10 @@ packages:
   /@types/ember__controller/4.0.4:
     resolution: {integrity: sha512-+f0knTIJJkRX5xijeSI/n4FvLfhMFFxIxODyFFFFB483EryYuts3QzpTwU5D66WQ5rAbZvpPRXRMPTTCNJoUhg==}
     dependencies:
-      '@types/ember__object': 4.0.5_@babel+core@7.20.12
+      '@types/ember__object': 4.0.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
     dev: true
 
   /@types/ember__controller/4.0.4_@babel+core@7.20.12:
@@ -3063,8 +3067,11 @@ packages:
   /@types/ember__object/4.0.5:
     resolution: {integrity: sha512-gXrywWBwoW7J9y9yJqoZ0m1qtiyMdrEi29cJdF1xI2qOnMqaZeuSCMYaPQMsyq52/YnVIG2EnGzo6eUD57J4Nw==}
     dependencies:
-      '@types/ember': 4.0.3_@babel+core@7.20.12
+      '@types/ember': 4.0.3
       '@types/rsvp': 4.0.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
     dev: true
 
   /@types/ember__object/4.0.5_@babel+core@7.20.12:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,7 @@ importers:
       '@types/ember__debug': ^4.0.0
       '@types/ember__engine': ^4.0.0
       '@types/ember__error': ^4.0.0
+      '@types/ember__modifier': ^4.0.3
       '@types/ember__object': ^4.0.0
       '@types/ember__polyfills': ^4.0.0
       '@types/ember__routing': ^4.0.0
@@ -90,6 +91,7 @@ importers:
       '@types/ember__debug': 4.0.3_@babel+core@7.20.12
       '@types/ember__engine': 4.0.4_@babel+core@7.20.12
       '@types/ember__error': 4.0.2
+      '@types/ember__modifier': 4.0.3_@babel+core@7.20.12
       '@types/ember__object': 4.0.5_@babel+core@7.20.12
       '@types/ember__polyfills': 4.0.1
       '@types/ember__routing': 4.0.12_@babel+core@7.20.12
@@ -2975,10 +2977,7 @@ packages:
   /@types/ember__controller/4.0.4:
     resolution: {integrity: sha512-+f0knTIJJkRX5xijeSI/n4FvLfhMFFxIxODyFFFFB483EryYuts3QzpTwU5D66WQ5rAbZvpPRXRMPTTCNJoUhg==}
     dependencies:
-      '@types/ember__object': 4.0.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
+      '@types/ember__object': 4.0.5_@babel+core@7.20.12
     dev: true
 
   /@types/ember__controller/4.0.4_@babel+core@7.20.12:
@@ -3051,14 +3050,21 @@ packages:
       - supports-color
     dev: true
 
-  /@types/ember__object/4.0.5:
-    resolution: {integrity: sha512-gXrywWBwoW7J9y9yJqoZ0m1qtiyMdrEi29cJdF1xI2qOnMqaZeuSCMYaPQMsyq52/YnVIG2EnGzo6eUD57J4Nw==}
+  /@types/ember__modifier/4.0.3_@babel+core@7.20.12:
+    resolution: {integrity: sha512-2Z4ty8OZNVO/UkypnVMoqdp57OxRd48dko3wYzYMbjhR7Wi2Gtd374dLlhoA6WXcWnEyrz7SUCot8zyBpBZwfg==}
     dependencies:
-      '@types/ember': 4.0.3
-      '@types/rsvp': 4.0.4
+      '@types/ember': 4.0.3_@babel+core@7.20.12
+      '@types/ember__owner': 4.0.3
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+    dev: true
+
+  /@types/ember__object/4.0.5:
+    resolution: {integrity: sha512-gXrywWBwoW7J9y9yJqoZ0m1qtiyMdrEi29cJdF1xI2qOnMqaZeuSCMYaPQMsyq52/YnVIG2EnGzo6eUD57J4Nw==}
+    dependencies:
+      '@types/ember': 4.0.3_@babel+core@7.20.12
+      '@types/rsvp': 4.0.4
     dev: true
 
   /@types/ember__object/4.0.5_@babel+core@7.20.12:

--- a/test-app/app/templates/index.hbs
+++ b/test-app/app/templates/index.hbs
@@ -1,4 +1,9 @@
-<HeadlessForm @data={{this.data}} @onSubmit={{this.doSomething}} as |form|>
+<HeadlessForm
+  @data={{this.data}}
+  @validateOn='blur'
+  @onSubmit={{this.doSomething}}
+  as |form|
+>
   <form.field @name='name' as |field|>
     <field.label>Name</field.label>
     <field.input />

--- a/test-app/tests/integration/components/headless-form-validation-test.gts
+++ b/test-app/tests/integration/components/headless-form-validation-test.gts
@@ -884,6 +884,13 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
           validateCallback.calledWith({ ...data, firstName: 'Foo' }),
           '@validate is called with form data'
         );
+
+        await click('[data-test-submit]');
+
+        assert.true(
+          validateCallback.calledTwice,
+          '@validate is called again on submit'
+        );
       });
 
       test('field validation callback is called on blur', async function (assert) {
@@ -924,10 +931,17 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
           }),
           '@validate is called with form data'
         );
+
+        await click('[data-test-submit]');
+
+        assert.true(
+          validateCallback.calledTwice,
+          '@validate is called again on submit'
+        );
       });
 
       test('validation errors are exposed as field.errors on blur', async function (assert) {
-        const data: TestFormData = { firstName: 'Foo', lastName: 'Foo' };
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Foo' };
 
         await render(<template>
           <HeadlessForm
@@ -1020,6 +1034,13 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
           validateCallback.calledWith({ ...data, firstName: 'Foo' }),
           '@validate is called with form data'
         );
+
+        await click('[data-test-submit]');
+
+        assert.true(
+          validateCallback.calledTwice,
+          '@validate is called again on submit'
+        );
       });
 
       test('field validation callback is called on change', async function (assert) {
@@ -1053,10 +1074,17 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
           }),
           '@validate is called with form data'
         );
+
+        await click('[data-test-submit]');
+
+        assert.true(
+          validateCallback.calledTwice,
+          '@validate is called again on submit'
+        );
       });
 
       test('validation errors are exposed as field.errors on change', async function (assert) {
-        const data: TestFormData = { firstName: 'Foo', lastName: 'Foo' };
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Foo' };
 
         await render(<template>
           <HeadlessForm
@@ -1102,6 +1130,491 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
           .dom('[data-test-last-name-errors]')
           .doesNotExist(
             'validation errors are not rendered for untouched fields'
+          );
+      });
+    });
+  });
+
+  module(`@revalidateOn`, function () {
+    module('blur', function () {
+      test('form validation callback is called on blur', async function (assert) {
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
+        const validateCallback = sinon.spy();
+
+        await render(<template>
+          <HeadlessForm
+            @data={{data}}
+            @revalidateOn="blur"
+            @validate={{validateCallback}}
+            as |form|
+          >
+            <form.field @name="firstName" as |field|>
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
+
+        await fillIn('[data-test-first-name]', 'Foo');
+
+        assert.false(
+          validateCallback.called,
+          '@validate is not called while typing'
+        );
+
+        await blur('[data-test-first-name]');
+
+        assert.false(
+          validateCallback.called,
+          '@validate is not called until submitting'
+        );
+
+        await click('[data-test-submit]');
+
+        assert.true(
+          validateCallback.calledOnce,
+          '@validate is called when submitting'
+        );
+        assert.true(
+          validateCallback.calledWith({ ...data, firstName: 'Foo' }),
+          '@validate is called with form data'
+        );
+
+        await fillIn('[data-test-first-name]', 'Tony');
+
+        assert.false(
+          validateCallback.calledTwice,
+          '@validate is not called while typing'
+        );
+
+        await blur('[data-test-first-name]');
+
+        assert.true(
+          validateCallback.calledTwice,
+          '@validate is called for revalidation on blur'
+        );
+        assert.true(
+          validateCallback
+            .getCall(1)
+            .calledWith({ ...data, firstName: 'Tony' }),
+          '@validate is called with form data'
+        );
+      });
+
+      test('field validation callback is called on blur', async function (assert) {
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
+        const validateCallback = sinon.spy();
+
+        await render(<template>
+          <HeadlessForm @data={{data}} @revalidateOn="blur" as |form|>
+            <form.field
+              @name="firstName"
+              @validate={{validateCallback}}
+              as |field|
+            >
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
+
+        await fillIn('[data-test-first-name]', 'Foo');
+
+        assert.false(
+          validateCallback.called,
+          '@validate is not called while typing'
+        );
+
+        await blur('[data-test-first-name]');
+
+        assert.false(
+          validateCallback.called,
+          '@validate is not called until submitting'
+        );
+
+        await click('[data-test-submit]');
+
+        assert.true(
+          validateCallback.calledOnce,
+          '@validate is called when submitting'
+        );
+        assert.true(
+          validateCallback.calledWith('Foo', 'firstName', {
+            ...data,
+            firstName: 'Foo',
+          }),
+          '@validate is called with form data'
+        );
+
+        await fillIn('[data-test-first-name]', 'Tony');
+
+        assert.false(
+          validateCallback.calledTwice,
+          '@validate is not called while typing'
+        );
+
+        await blur('[data-test-first-name]');
+
+        assert.true(
+          validateCallback.calledTwice,
+          '@validate is called for revalidation on blur'
+        );
+        assert.true(
+          validateCallback.getCall(1).calledWith('Tony', 'firstName', {
+            ...data,
+            firstName: 'Tony',
+          }),
+          '@validate is called with form data'
+        );
+      });
+
+      test('validation errors are exposed as field.errors on blur', async function (assert) {
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Foo' };
+
+        await render(<template>
+          <HeadlessForm
+            @data={{data}}
+            @revalidateOn="blur"
+            @validate={{validateFormCallbackSync}}
+            as |form|
+          >
+            <form.field @name="firstName" as |field|>
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+              <field.errors data-test-first-name-errors />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+              <field.errors data-test-last-name-errors />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before initial validation happens'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before initial validation happens'
+          );
+
+        await fillIn('[data-test-first-name]', 'Foo');
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before initial validation happens'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before initial validation happens'
+          );
+
+        await blur('[data-test-first-name]');
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before initial validation happens'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before initial validation happens'
+          );
+
+        await click('[data-test-submit]');
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .exists(
+            { count: 1 },
+            'validation errors appear on submit when validation fails'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .exists(
+            { count: 1 },
+            'validation errors appear on submit when validation fails'
+          );
+
+        await fillIn('[data-test-first-name]', 'Tony');
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .exists(
+            { count: 1 },
+            'validation errors do not disappear until revalidation happens'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .exists(
+            { count: 1 },
+            'validation errors do not disappear until revalidation happens'
+          );
+
+        await blur('[data-test-first-name]');
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .doesNotExist(
+            'validation errors disappear after successful revalidation'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .exists(
+            { count: 1 },
+            'validation errors do not disappear until revalidation happens'
+          );
+      });
+    });
+
+    module('change', function () {
+      test('form validation callback is called on change', async function (assert) {
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
+        const validateCallback = sinon.spy();
+
+        await render(<template>
+          <HeadlessForm
+            @data={{data}}
+            @revalidateOn="change"
+            @validate={{validateCallback}}
+            as |form|
+          >
+            <form.field @name="firstName" as |field|>
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
+
+        await fillIn('[data-test-first-name]', 'Foo');
+
+        assert.false(
+          validateCallback.called,
+          '@validate is not called while typing'
+        );
+
+        await blur('[data-test-first-name]');
+
+        assert.false(
+          validateCallback.called,
+          '@validate is not called until submitting'
+        );
+
+        await click('[data-test-submit]');
+
+        assert.true(
+          validateCallback.calledOnce,
+          '@validate is called when submitting'
+        );
+        assert.true(
+          validateCallback.calledWith({ ...data, firstName: 'Foo' }),
+          '@validate is called with form data'
+        );
+
+        await fillIn('[data-test-first-name]', 'Tony');
+
+        assert.true(
+          validateCallback.calledTwice,
+          '@validate is called for revalidation on change'
+        );
+        assert.true(
+          validateCallback
+            .getCall(1)
+            .calledWith({ ...data, firstName: 'Tony' }),
+          '@validate is called with form data'
+        );
+
+        await blur('[data-test-first-name]');
+
+        assert.true(
+          validateCallback.calledTwice,
+          '@validate is not called again on blur'
+        );
+      });
+
+      test('field validation callback is called on change', async function (assert) {
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
+        const validateCallback = sinon.spy();
+
+        await render(<template>
+          <HeadlessForm @data={{data}} @revalidateOn="change" as |form|>
+            <form.field
+              @name="firstName"
+              @validate={{validateCallback}}
+              as |field|
+            >
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
+
+        await fillIn('[data-test-first-name]', 'Foo');
+
+        assert.false(
+          validateCallback.called,
+          '@validate is not called while typing'
+        );
+
+        await blur('[data-test-first-name]');
+
+        assert.false(
+          validateCallback.called,
+          '@validate is not called until submitting'
+        );
+
+        await click('[data-test-submit]');
+
+        assert.true(
+          validateCallback.calledOnce,
+          '@validate is called when submitting'
+        );
+        assert.true(
+          validateCallback.calledWith('Foo', 'firstName', {
+            ...data,
+            firstName: 'Foo',
+          }),
+          '@validate is called with form data'
+        );
+
+        await fillIn('[data-test-first-name]', 'Tony');
+
+        assert.true(
+          validateCallback.calledTwice,
+          '@validate is called for revalidation on change'
+        );
+        assert.true(
+          validateCallback.getCall(1).calledWith('Tony', 'firstName', {
+            ...data,
+            firstName: 'Tony',
+          }),
+          '@validate is called with form data'
+        );
+
+        await blur('[data-test-first-name]');
+
+        assert.true(
+          validateCallback.calledTwice,
+          '@validate is called for revalidation on blur'
+        );
+      });
+
+      test('validation errors are exposed as field.errors on change', async function (assert) {
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Foo' };
+
+        await render(<template>
+          <HeadlessForm
+            @data={{data}}
+            @revalidateOn="change"
+            @validate={{validateFormCallbackSync}}
+            as |form|
+          >
+            <form.field @name="firstName" as |field|>
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+              <field.errors data-test-first-name-errors />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+              <field.errors data-test-last-name-errors />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before initial validation happens'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before initial validation happens'
+          );
+
+        await fillIn('[data-test-first-name]', 'Foo');
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before initial validation happens'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before initial validation happens'
+          );
+
+        await blur('[data-test-first-name]');
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before initial validation happens'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before initial validation happens'
+          );
+
+        await click('[data-test-submit]');
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .exists(
+            { count: 1 },
+            'validation errors appear on submit when validation fails'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .exists(
+            { count: 1 },
+            'validation errors appear on submit when validation fails'
+          );
+
+        await fillIn('[data-test-first-name]', 'Tony');
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .doesNotExist(
+            'validation errors disappear after successful revalidation'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .exists(
+            { count: 1 },
+            'validation errors do not disappear until revalidation happens'
           );
       });
     });

--- a/test-app/tests/integration/components/headless-form-validation-test.gts
+++ b/test-app/tests/integration/components/headless-form-validation-test.gts
@@ -67,7 +67,9 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
   const validateFormCallbackAsync: FormValidateCallback<TestFormData> = async (
     data
   ) => {
-    return await validateFormCallbackSync(data);
+    // intentionally adding a delay here, to make the validation behave truly async and assert that we are correctly waiting for it in tests
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    return validateFormCallbackSync(data);
   };
 
   const validateFieldCallbackSync: FieldValidateCallback<TestFormData> = (
@@ -105,7 +107,9 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
   const validateFieldCallbackAsync: FieldValidateCallback<
     TestFormData
   > = async (value, field, data) => {
-    return await validateFieldCallbackSync(value, field, data);
+    // intentionally adding a delay here, to make the validation behave truly async and assert that we are correctly waiting for it in tests
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    return validateFieldCallbackSync(value, field, data);
   };
 
   module('form @validation callback', function () {

--- a/test-app/tests/integration/components/headless-form-validation-test.gts
+++ b/test-app/tests/integration/components/headless-form-validation-test.gts
@@ -847,7 +847,7 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
   });
 
   module(`@validateOn`, function () {
-    module('blur', function () {
+    module('@validateOn=blur', function () {
       test('form validation callback is called on blur', async function (assert) {
         const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
         const validateCallback = sinon.spy();
@@ -1004,7 +1004,7 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
       });
     });
 
-    module('change', function () {
+    module('@validateOn=change', function () {
       test('form validation callback is called on change', async function (assert) {
         const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
         const validateCallback = sinon.spy();
@@ -1136,7 +1136,7 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
   });
 
   module(`@revalidateOn`, function () {
-    module('blur', function () {
+    module('@revalidateOn=blur', function () {
       test('form validation callback is called on blur', async function (assert) {
         const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
         const validateCallback = sinon.spy();
@@ -1385,7 +1385,7 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
       });
     });
 
-    module('change', function () {
+    module('@revalidateOn=change', function () {
       test('form validation callback is called on change', async function (assert) {
         const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
         const validateCallback = sinon.spy();

--- a/test-app/tests/integration/components/headless-form-validation-test.gts
+++ b/test-app/tests/integration/components/headless-form-validation-test.gts
@@ -882,7 +882,7 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
 
         assert.true(
           validateCallback.calledWith({ ...data, firstName: 'Foo' }),
-          '@validate is called with form data'
+          '@validate is called with form data on blur'
         );
 
         await click('[data-test-submit]');
@@ -929,7 +929,7 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
             ...data,
             firstName: 'Foo',
           }),
-          '@validate is called with form data'
+          '@validate is called with form data on blur'
         );
 
         await click('[data-test-submit]');
@@ -967,12 +967,12 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
         assert
           .dom('[data-test-first-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before validation happens'
+            'validation errors are not rendered before form is filled in'
           );
         assert
           .dom('[data-test-last-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before validation happens'
+            'validation errors are not rendered before form is filled in'
           );
 
         await fillIn('[data-test-first-name]', 'Foo');
@@ -980,12 +980,12 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
         assert
           .dom('[data-test-first-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before validation happens'
+            'validation errors are not rendered before validation happens on blur'
           );
         assert
           .dom('[data-test-last-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before validation happens'
+            'validation errors are not rendered before validation happens on blur'
           );
 
         await blur('[data-test-first-name]');
@@ -1032,7 +1032,7 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
 
         assert.true(
           validateCallback.calledWith({ ...data, firstName: 'Foo' }),
-          '@validate is called with form data'
+          '@validate is called with form data on change'
         );
 
         await click('[data-test-submit]');
@@ -1110,12 +1110,12 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
         assert
           .dom('[data-test-first-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before validation happens'
+            'validation errors are not rendered before validation happens on change'
           );
         assert
           .dom('[data-test-last-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before validation happens'
+            'validation errors are not rendered before validation happens on change'
           );
 
         await fillIn('[data-test-first-name]', 'Foo');
@@ -1182,7 +1182,7 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
         );
         assert.true(
           validateCallback.calledWith({ ...data, firstName: 'Foo' }),
-          '@validate is called with form data'
+          '@validate is called with form data on submit'
         );
 
         await fillIn('[data-test-first-name]', 'Tony');
@@ -1202,7 +1202,7 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
           validateCallback
             .getCall(1)
             .calledWith({ ...data, firstName: 'Tony' }),
-          '@validate is called with form data'
+          '@validate is called with form data on blur'
         );
       });
 
@@ -1305,12 +1305,12 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
         assert
           .dom('[data-test-first-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before initial validation happens'
+            'validation errors are not rendered before initial validation happens before form is filled in'
           );
         assert
           .dom('[data-test-last-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before initial validation happens'
+            'validation errors are not rendered before initial validation happens before form is filled in'
           );
 
         await fillIn('[data-test-first-name]', 'Foo');
@@ -1318,12 +1318,12 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
         assert
           .dom('[data-test-first-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before initial validation happens'
+            'validation errors are not rendered before initial validation happens on submit'
           );
         assert
           .dom('[data-test-last-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before initial validation happens'
+            'validation errors are not rendered before initial validation happens on submit'
           );
 
         await blur('[data-test-first-name]');
@@ -1331,12 +1331,12 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
         assert
           .dom('[data-test-first-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before initial validation happens'
+            'validation errors are not rendered before initial validation happens on submit'
           );
         assert
           .dom('[data-test-last-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before initial validation happens'
+            'validation errors are not rendered before initial validation happens on submit'
           );
 
         await click('[data-test-submit]');
@@ -1360,13 +1360,13 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
           .dom('[data-test-first-name-errors]')
           .exists(
             { count: 1 },
-            'validation errors do not disappear until revalidation happens'
+            'validation errors do not disappear until revalidation happens on blur'
           );
         assert
           .dom('[data-test-last-name-errors]')
           .exists(
             { count: 1 },
-            'validation errors do not disappear until revalidation happens'
+            'validation errors do not disappear until revalidation happens on blur'
           );
 
         await blur('[data-test-first-name]');
@@ -1374,13 +1374,13 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
         assert
           .dom('[data-test-first-name-errors]')
           .doesNotExist(
-            'validation errors disappear after successful revalidation'
+            'validation errors disappear after successful revalidation on blur'
           );
         assert
           .dom('[data-test-last-name-errors]')
           .exists(
             { count: 1 },
-            'validation errors do not disappear until revalidation happens'
+            'validation errors do not disappear until revalidation happens on blur'
           );
       });
     });
@@ -1554,12 +1554,12 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
         assert
           .dom('[data-test-first-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before initial validation happens'
+            'validation errors are not rendered before initial validation happens before form is filled in'
           );
         assert
           .dom('[data-test-last-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before initial validation happens'
+            'validation errors are not rendered before initial validation happens before form is filled in'
           );
 
         await fillIn('[data-test-first-name]', 'Foo');
@@ -1567,12 +1567,12 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
         assert
           .dom('[data-test-first-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before initial validation happens'
+            'validation errors are not rendered before initial validation happens on submit'
           );
         assert
           .dom('[data-test-last-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before initial validation happens'
+            'validation errors are not rendered before initial validation happens on submit'
           );
 
         await blur('[data-test-first-name]');
@@ -1580,12 +1580,12 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
         assert
           .dom('[data-test-first-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before initial validation happens'
+            'validation errors are not rendered before initial validation happens on submit'
           );
         assert
           .dom('[data-test-last-name-errors]')
           .doesNotExist(
-            'validation errors are not rendered before initial validation happens'
+            'validation errors are not rendered before initial validation happens on submit'
           );
 
         await click('[data-test-submit]');
@@ -1608,13 +1608,13 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
         assert
           .dom('[data-test-first-name-errors]')
           .doesNotExist(
-            'validation errors disappear after successful revalidation'
+            'validation errors disappear after successful revalidation on change'
           );
         assert
           .dom('[data-test-last-name-errors]')
           .exists(
             { count: 1 },
-            'validation errors do not disappear until revalidation happens'
+            'validation errors do not disappear until revalidation happens on change'
           );
       });
     });

--- a/test-app/tests/integration/components/headless-form-validation-test.gts
+++ b/test-app/tests/integration/components/headless-form-validation-test.gts
@@ -846,146 +846,264 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
     );
   });
 
-  module('@validateOn="blur"', function () {
-    test('form validation callback is called on blur', async function (assert) {
-      const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
-      const validateCallback = sinon.spy();
+  module(`@validateOn`, function () {
+    module('blur', function () {
+      test('form validation callback is called on blur', async function (assert) {
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
+        const validateCallback = sinon.spy();
 
-      await render(<template>
-        <HeadlessForm
-          @data={{data}}
-          @validateOn="blur"
-          @validate={{validateCallback}}
-          as |form|
-        >
-          <form.field @name="firstName" as |field|>
-            <field.label>First Name</field.label>
-            <field.input data-test-first-name />
-          </form.field>
-          <form.field @name="lastName" as |field|>
-            <field.label>Last Name</field.label>
-            <field.input data-test-last-name />
-          </form.field>
-          <button type="submit" data-test-submit>Submit</button>
-        </HeadlessForm>
-      </template>);
-
-      await fillIn('[data-test-first-name]', 'Foo');
-
-      assert.false(
-        validateCallback.called,
-        '@validate is not called while typing'
-      );
-
-      await blur('[data-test-first-name]');
-
-      assert.true(
-        validateCallback.calledWith({ ...data, firstName: 'Foo' }),
-        '@validate is called with form data'
-      );
-    });
-
-    test('field validation callback is called on blur', async function (assert) {
-      const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
-      const validateCallback = sinon.spy();
-
-      await render(<template>
-        <HeadlessForm @data={{data}} @validateOn="blur" as |form|>
-          <form.field
-            @name="firstName"
+        await render(<template>
+          <HeadlessForm
+            @data={{data}}
+            @validateOn="blur"
             @validate={{validateCallback}}
-            as |field|
+            as |form|
           >
-            <field.label>First Name</field.label>
-            <field.input data-test-first-name />
-          </form.field>
-          <form.field @name="lastName" as |field|>
-            <field.label>Last Name</field.label>
-            <field.input data-test-last-name />
-          </form.field>
-          <button type="submit" data-test-submit>Submit</button>
-        </HeadlessForm>
-      </template>);
+            <form.field @name="firstName" as |field|>
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
 
-      await fillIn('[data-test-first-name]', 'Foo');
+        await fillIn('[data-test-first-name]', 'Foo');
 
-      assert.false(
-        validateCallback.called,
-        '@validate is not called while typing'
-      );
+        assert.false(
+          validateCallback.called,
+          '@validate is not called while typing'
+        );
 
-      await blur('[data-test-first-name]');
+        await blur('[data-test-first-name]');
 
-      assert.true(
-        validateCallback.calledWith('Foo', 'firstName', {
-          ...data,
-          firstName: 'Foo',
-        }),
-        '@validate is called with form data'
-      );
+        assert.true(
+          validateCallback.calledWith({ ...data, firstName: 'Foo' }),
+          '@validate is called with form data'
+        );
+      });
+
+      test('field validation callback is called on blur', async function (assert) {
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
+        const validateCallback = sinon.spy();
+
+        await render(<template>
+          <HeadlessForm @data={{data}} @validateOn="blur" as |form|>
+            <form.field
+              @name="firstName"
+              @validate={{validateCallback}}
+              as |field|
+            >
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
+
+        await fillIn('[data-test-first-name]', 'Foo');
+
+        assert.false(
+          validateCallback.called,
+          '@validate is not called while typing'
+        );
+
+        await blur('[data-test-first-name]');
+
+        assert.true(
+          validateCallback.calledWith('Foo', 'firstName', {
+            ...data,
+            firstName: 'Foo',
+          }),
+          '@validate is called with form data'
+        );
+      });
+
+      test('validation errors are exposed as field.errors on blur', async function (assert) {
+        const data: TestFormData = { firstName: 'Foo', lastName: 'Foo' };
+
+        await render(<template>
+          <HeadlessForm
+            @data={{data}}
+            @validateOn="blur"
+            @validate={{validateFormCallbackSync}}
+            as |form|
+          >
+            <form.field @name="firstName" as |field|>
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+              <field.errors data-test-first-name-errors />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+              <field.errors data-test-last-name-errors />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before validation happens'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before validation happens'
+          );
+
+        await fillIn('[data-test-first-name]', 'Foo');
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before validation happens'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before validation happens'
+          );
+
+        await blur('[data-test-first-name]');
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .exists(
+            { count: 1 },
+            'validation errors appear on blur when validation fails'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered for untouched fields'
+          );
+      });
     });
 
-    test('validation errors are exposed as field.errors on blur', async function (assert) {
-      const data: TestFormData = { firstName: 'Foo', lastName: 'Foo' };
+    module('change', function () {
+      test('form validation callback is called on change', async function (assert) {
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
+        const validateCallback = sinon.spy();
 
-      await render(<template>
-        <HeadlessForm
-          @data={{data}}
-          @validateOn="blur"
-          @validate={{validateFormCallbackSync}}
-          as |form|
-        >
-          <form.field @name="firstName" as |field|>
-            <field.label>First Name</field.label>
-            <field.input data-test-first-name />
-            <field.errors data-test-first-name-errors />
-          </form.field>
-          <form.field @name="lastName" as |field|>
-            <field.label>Last Name</field.label>
-            <field.input data-test-last-name />
-            <field.errors data-test-last-name-errors />
-          </form.field>
-          <button type="submit" data-test-submit>Submit</button>
-        </HeadlessForm>
-      </template>);
+        await render(<template>
+          <HeadlessForm
+            @data={{data}}
+            @validateOn="change"
+            @validate={{validateCallback}}
+            as |form|
+          >
+            <form.field @name="firstName" as |field|>
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
 
-      assert
-        .dom('[data-test-first-name-errors]')
-        .doesNotExist(
-          'validation errors are not rendered before validation happens'
-        );
-      assert
-        .dom('[data-test-last-name-errors]')
-        .doesNotExist(
-          'validation errors are not rendered before validation happens'
-        );
+        await fillIn('[data-test-first-name]', 'Foo');
 
-      await fillIn('[data-test-first-name]', 'Foo');
+        assert.true(
+          validateCallback.calledWith({ ...data, firstName: 'Foo' }),
+          '@validate is called with form data'
+        );
+      });
 
-      assert
-        .dom('[data-test-first-name-errors]')
-        .doesNotExist(
-          'validation errors are not rendered before validation happens'
-        );
-      assert
-        .dom('[data-test-last-name-errors]')
-        .doesNotExist(
-          'validation errors are not rendered before validation happens'
-        );
+      test('field validation callback is called on change', async function (assert) {
+        const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
+        const validateCallback = sinon.spy();
 
-      await blur('[data-test-first-name]');
+        await render(<template>
+          <HeadlessForm @data={{data}} @validateOn="change" as |form|>
+            <form.field
+              @name="firstName"
+              @validate={{validateCallback}}
+              as |field|
+            >
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
 
-      assert
-        .dom('[data-test-first-name-errors]')
-        .exists(
-          { count: 1 },
-          'validation errors appear on blur when validation fails'
+        await fillIn('[data-test-first-name]', 'Foo');
+
+        assert.true(
+          validateCallback.calledWith('Foo', 'firstName', {
+            ...data,
+            firstName: 'Foo',
+          }),
+          '@validate is called with form data'
         );
-      assert
-        .dom('[data-test-last-name-errors]')
-        .doesNotExist(
-          'validation errors are not rendered for untouched fields'
-        );
+      });
+
+      test('validation errors are exposed as field.errors on change', async function (assert) {
+        const data: TestFormData = { firstName: 'Foo', lastName: 'Foo' };
+
+        await render(<template>
+          <HeadlessForm
+            @data={{data}}
+            @validateOn="change"
+            @validate={{validateFormCallbackSync}}
+            as |form|
+          >
+            <form.field @name="firstName" as |field|>
+              <field.label>First Name</field.label>
+              <field.input data-test-first-name />
+              <field.errors data-test-first-name-errors />
+            </form.field>
+            <form.field @name="lastName" as |field|>
+              <field.label>Last Name</field.label>
+              <field.input data-test-last-name />
+              <field.errors data-test-last-name-errors />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before validation happens'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered before validation happens'
+          );
+
+        await fillIn('[data-test-first-name]', 'Foo');
+
+        assert
+          .dom('[data-test-first-name-errors]')
+          .exists(
+            { count: 1 },
+            'validation errors appear on blur when validation fails'
+          );
+        assert
+          .dom('[data-test-last-name-errors]')
+          .doesNotExist(
+            'validation errors are not rendered for untouched fields'
+          );
+      });
     });
   });
 });


### PR DESCRIPTION
As an iteration over #21, this adds the options to validate and revalidate (when initial validation had errors) not only on submit, but also on blur/focusout and change.

It supersedes #24, and still relies on option 1 discussed in that draft PR. In a future iteration it is expected that we had further primitives for custom controls, like "option 4" of yielding a modifier to capture focusout/change event, or yielding more validation state like `field.isValid`. But this can all be done on top of this PR. 