### PR TITLE
Support custom controls

### DIFF
--- a/ember-headless-form/package.json
+++ b/ember-headless-form/package.json
@@ -30,6 +30,7 @@
     "@embroider/addon-shim": "^1.0.0",
     "@ember/test-waiters": "^3.0.2",
     "@embroider/util": "^1.9.0",
+    "ember-modifier": "^4.0.0",
     "tracked-built-ins": "^3.1.0"
   },
   "peerDependencies": {

--- a/ember-headless-form/src/components/-private/capture-events.ts
+++ b/ember-headless-form/src/components/-private/capture-events.ts
@@ -1,0 +1,23 @@
+import { modifier } from 'ember-modifier';
+
+export interface CaptureEventsModifierSignature {
+  Element: HTMLElement;
+  Args: {
+    Named: {
+      event: 'focusout' | 'change';
+      triggerValidation(): void;
+    };
+  };
+}
+
+const CaptureEventsModifier = modifier<CaptureEventsModifierSignature>(
+  (element, _pos, { event, triggerValidation }) => {
+    element.addEventListener(event, triggerValidation, { passive: true });
+
+    return () => {
+      element.removeEventListener(event, triggerValidation);
+    };
+  }
+);
+
+export default CaptureEventsModifier;

--- a/ember-headless-form/src/components/-private/field.hbs
+++ b/ember-headless-form/src/components/-private/field.hbs
@@ -48,6 +48,7 @@
           id=errorId
         )
       )
+      triggerValidation=(fn @triggerValidationFor @name)
     )
   }}
 {{/let}}

--- a/ember-headless-form/src/components/-private/field.hbs
+++ b/ember-headless-form/src/components/-private/field.hbs
@@ -1,4 +1,10 @@
-{{#let (unique-id) (unique-id) (fn @set @name) as |fieldId errorId setValue|}}
+{{#let
+  (unique-id)
+  (unique-id)
+  (fn @set @name)
+  (fn @triggerValidationFor @name)
+  as |fieldId errorId setValue triggerValidation|
+}}
   {{yield
     (hash
       label=(component
@@ -48,7 +54,12 @@
           id=errorId
         )
       )
-      triggerValidation=(fn @triggerValidationFor @name)
+      triggerValidation=triggerValidation
+      captureEvents=(modifier
+        this.CaptureEventsModifier
+        event=(if this.hasErrors @fieldRevalidationEvent @fieldValidationEvent)
+        triggerValidation=triggerValidation
+      )
     )
   }}
 {{/let}}

--- a/ember-headless-form/src/components/-private/field.hbs
+++ b/ember-headless-form/src/components/-private/field.hbs
@@ -44,8 +44,9 @@
         setValue=this.setValue
       )
       value=this.value
-      id=fieldId
       setValue=setValue
+      id=fieldId
+      errorId=errorId
       errors=(if
         this.errors
         (component
@@ -54,6 +55,7 @@
           id=errorId
         )
       )
+      isInvalid=this.hasErrors
       triggerValidation=triggerValidation
       captureEvents=(modifier
         this.CaptureEventsModifier

--- a/ember-headless-form/src/components/-private/field.ts
+++ b/ember-headless-form/src/components/-private/field.ts
@@ -68,12 +68,14 @@ export interface HeadlessFormFieldComponentSignature<
           'name' | 'fieldId' | 'value' | 'setValue' | 'invalid' | 'errorId'
         >;
         value: DATA[KEY];
-        id: string;
         setValue: (value: DATA[KEY]) => void;
+        id: string;
+        errorId: string;
         errors?: WithBoundArgs<
           typeof ErrorsComponent<DATA[KEY]>,
           'errors' | 'id'
         >;
+        isInvalid: boolean;
         triggerValidation: () => void;
         captureEvents: WithBoundArgs<
           ModifierLike<CaptureEventsModifierSignature>,

--- a/ember-headless-form/src/components/-private/field.ts
+++ b/ember-headless-form/src/components/-private/field.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 
+import CaptureEventsModifier from './capture-events';
 import CheckboxComponent from './control/checkbox';
 import InputComponent from './control/input';
 import RadioComponent from './control/radio';
@@ -9,6 +10,7 @@ import TextareaComponent from './control/textarea';
 import ErrorsComponent from './errors';
 import LabelComponent from './label';
 
+import type { CaptureEventsModifierSignature } from './capture-events';
 import type { HeadlessFormControlCheckboxComponentSignature } from './control/checkbox';
 import type { HeadlessFormControlInputComponentSignature } from './control/input';
 import type { HeadlessFormControlRadioComponentSignature } from './control/radio';
@@ -23,7 +25,11 @@ import type {
   UnregisterFieldCallback,
 } from './types';
 import type { FormKey, UserData, ValidationError } from './types';
-import type { ComponentLike, WithBoundArgs } from '@glint/template';
+import type {
+  ComponentLike,
+  ModifierLike,
+  WithBoundArgs,
+} from '@glint/template';
 
 export interface HeadlessFormFieldComponentSignature<
   DATA extends UserData,
@@ -37,7 +43,9 @@ export interface HeadlessFormFieldComponentSignature<
     errors?: ErrorRecord<DATA, KEY>;
     registerField: RegisterFieldCallback<FormData<DATA>, KEY>;
     unregisterField: UnregisterFieldCallback<FormData<DATA>, KEY>;
-    triggerValidationFor(name: string): Promise<void>;
+    triggerValidationFor(name: KEY): Promise<void>;
+    fieldValidationEvent: 'focusout' | 'change' | undefined;
+    fieldRevalidationEvent: 'focusout' | 'change' | undefined;
   };
   Blocks: {
     default: [
@@ -67,6 +75,10 @@ export interface HeadlessFormFieldComponentSignature<
           'errors' | 'id'
         >;
         triggerValidation: () => void;
+        captureEvents: WithBoundArgs<
+          ModifierLike<CaptureEventsModifierSignature>,
+          'event' | 'triggerValidation'
+        >;
       }
     ];
   };
@@ -89,6 +101,7 @@ export default class HeadlessFormFieldComponent<
     TextareaComponent;
   RadioComponent: ComponentLike<HeadlessFormControlRadioComponentSignature> =
     RadioComponent;
+  CaptureEventsModifier = CaptureEventsModifier;
 
   constructor(
     owner: unknown,

--- a/ember-headless-form/src/components/-private/field.ts
+++ b/ember-headless-form/src/components/-private/field.ts
@@ -37,6 +37,7 @@ export interface HeadlessFormFieldComponentSignature<
     errors?: ErrorRecord<DATA, KEY>;
     registerField: RegisterFieldCallback<FormData<DATA>, KEY>;
     unregisterField: UnregisterFieldCallback<FormData<DATA>, KEY>;
+    triggerValidationFor(name: string): Promise<void>;
   };
   Blocks: {
     default: [
@@ -65,6 +66,7 @@ export interface HeadlessFormFieldComponentSignature<
           typeof ErrorsComponent<DATA[KEY]>,
           'errors' | 'id'
         >;
+        triggerValidation: () => void;
       }
     ];
   };

--- a/ember-headless-form/src/components/headless-form.hbs
+++ b/ember-headless-form/src/components/headless-form.hbs
@@ -17,6 +17,7 @@
         errors=this.visibleErrors
         registerField=this.registerField
         unregisterField=this.unregisterField
+        triggerValidationFor=this.handleFieldValidation
       )
     )
   }}

--- a/ember-headless-form/src/components/headless-form.hbs
+++ b/ember-headless-form/src/components/headless-form.hbs
@@ -1,12 +1,14 @@
-{{! ignoring prettier here is need to *not* wrap the modifier usage below into a new line, making @glint-expect-error fail to work 🙈 }}
-{{! prettier-ignore }}
 <form
   ...attributes
   {{on 'submit' this.onSubmit}}
-  {{! @glint-expect-error: modifier helper not supported, see https://github.com/typed-ember/glint/issues/410 }}
-  {{(if this.fieldValidationEvent (modifier this.on this.fieldValidationEvent this.handleFieldValidation))}}
-  {{! @glint-expect-error: modifier helper not supported, see https://github.com/typed-ember/glint/issues/410 }}
-  {{(if this.fieldRevalidationEvent (modifier this.on this.fieldRevalidationEvent this.handleFieldRevalidation))}}
+  {{(if
+    this.fieldValidationEvent
+    (modifier this.on this.fieldValidationEvent this.handleFieldValidation)
+  )}}
+  {{(if
+    this.fieldRevalidationEvent
+    (modifier this.on this.fieldRevalidationEvent this.handleFieldRevalidation)
+  )}}
 >
   {{yield
     (hash
@@ -18,6 +20,8 @@
         registerField=this.registerField
         unregisterField=this.unregisterField
         triggerValidationFor=this.handleFieldValidation
+        fieldValidationEvent=this.fieldValidationEvent
+        fieldRevalidationEvent=this.fieldRevalidationEvent
       )
     )
   }}

--- a/ember-headless-form/src/components/headless-form.ts
+++ b/ember-headless-form/src/components/headless-form.ts
@@ -42,7 +42,12 @@ export interface HeadlessFormComponentSignature<DATA extends UserData> {
       {
         field: WithBoundArgs<
           typeof FieldComponent<DATA>,
-          'data' | 'set' | 'errors' | 'registerField' | 'unregisterField'
+          | 'data'
+          | 'set'
+          | 'errors'
+          | 'registerField'
+          | 'unregisterField'
+          | 'triggerValidationFor'
         >;
       }
     ];
@@ -267,9 +272,16 @@ export default class HeadlessFormComponent<
    * Validation will be triggered, and the particular field will be marked to show eventual validation errors.
    */
   @action
-  async handleFieldValidation(e: Event): Promise<void> {
-    const { target } = e;
-    const { name } = target as HTMLInputElement;
+  async handleFieldValidation(e: Event | string): Promise<void> {
+    let name: string;
+
+    if (typeof e === 'string') {
+      name = e;
+    } else {
+      const { target } = e;
+
+      name = (target as HTMLInputElement).name;
+    }
 
     if (name) {
       const field = this.fields.get(name as FormKey<FormData<DATA>>);

--- a/ember-headless-form/src/components/headless-form.ts
+++ b/ember-headless-form/src/components/headless-form.ts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { assert } from '@ember/debug';
+import { assert, warn } from '@ember/debug';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { waitFor } from '@ember/test-waiters';
@@ -292,8 +292,11 @@ export default class HeadlessFormComponent<
         this.lastValidationResult = await this.validate();
         field.validationEnabled = true;
       }
-    } else {
-      // @todo how to handle custom controls that don't emit focusout/change events from native form controls?
+    } else if (e instanceof Event) {
+      warn(
+        `An event of type "${e.type}" was received by headless-form, which is supposed to trigger validations for a certain field. But the name of that field could not be determined. Make sure that your control element has a \`name\` attribute matching the field, or use the yielded \`{{field.captureEvents}}\` to capture the events.`,
+        { id: 'headless-form.validation-event-for-unknown-field' }
+      );
     }
   }
 
@@ -314,7 +317,10 @@ export default class HeadlessFormComponent<
         this.lastValidationResult = await this.validate();
       }
     } else {
-      // @todo how to handle custom controls that don't emit focusout/change events from native form controls?
+      warn(
+        `An event of type "${e.type}" was received by headless-form, which is supposed to trigger validations for a certain field. But the name of that field could not be determined. Make sure that your control element has a \`name\` attribute matching the field, or use the yielded \`{{field.captureEvents}}\` to capture the events.`,
+        { id: 'headless-form.validation-event-for-unknown-field' }
+      );
     }
   }
 }

--- a/ember-headless-form/src/components/headless-form.ts
+++ b/ember-headless-form/src/components/headless-form.ts
@@ -48,6 +48,8 @@ export interface HeadlessFormComponentSignature<DATA extends UserData> {
           | 'registerField'
           | 'unregisterField'
           | 'triggerValidationFor'
+          | 'fieldValidationEvent'
+          | 'fieldRevalidationEvent'
         >;
       }
     ];

--- a/ember-headless-form/unpublished-development-types/index.d.ts
+++ b/ember-headless-form/unpublished-development-types/index.d.ts
@@ -22,5 +22,8 @@ declare module '@glint/environment-ember-loose/registry' {
     // See https://typed-ember.gitbook.io/glint/using-glint/ember/using-addons
 
     'ensure-safe-component': typeof ensureSafeComponent;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- effectively skipping type checks until https://github.com/typed-ember/glint/issues/410 is resolved
+    modifier: any;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.30.5
       '@typescript-eslint/parser': ^5.30.5
       concurrently: ^7.2.1
+      ember-modifier: ^4.0.0
       ember-template-lint: ^4.0.0
       eslint: ^7.32.0
       eslint-config-prettier: ^8.3.0
@@ -70,6 +71,7 @@ importers:
       '@ember/test-waiters': 3.0.2
       '@embroider/addon-shim': 1.8.4
       '@embroider/util': 1.9.0
+      ember-modifier: 4.0.0
       tracked-built-ins: 3.1.0
     devDependencies:
       '@babel/core': 7.20.12
@@ -81,7 +83,7 @@ importers:
       '@glimmer/component': 1.1.2_@babel+core@7.20.12
       '@glimmer/tracking': 1.1.2
       '@glint/core': 0.9.7_typescript@4.9.4
-      '@glint/environment-ember-loose': 0.9.7_@glimmer+component@1.1.2
+      '@glint/environment-ember-loose': 0.9.7_tgsz7vcw3ssws4mirvv5ovlu7q
       '@glint/template': 0.9.7_@glimmer+component@1.1.2
       '@nullvoxpopuli/eslint-configs': 3.0.2_n6t5m3hzq3ztahyqqb3gge4faa
       '@tsconfig/ember': 1.1.0
@@ -2078,7 +2080,6 @@ packages:
       semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@embroider/core/2.0.2:
     resolution: {integrity: sha512-noxrIOTiOI8ZW9s7hLCOhSHfsttgkPXN1on/2aovCHza0lQ9DNi4V5Ybpd4QMaTh+OzsrLGnV9qdj7kd9GpWSg==}
@@ -2376,25 +2377,6 @@ packages:
       - supports-color
     dev: true
 
-  /@glint/environment-ember-loose/0.9.7_@glimmer+component@1.1.2:
-    resolution: {integrity: sha512-MlCGZtB1Clp4vQWIm2APSnCm7nL8wVhFMOhVy2qzpV0nfLyg3pcN9CQHNpfdJvCydBB72cA4/ahPj7VEFL6xsg==}
-    peerDependencies:
-      '@glimmer/component': ^1.1.2
-      ember-cli-htmlbars: ^6.0.1
-      ember-modifier: ^3.2.7
-    peerDependenciesMeta:
-      ember-cli-htmlbars:
-        optional: true
-      ember-modifier:
-        optional: true
-    dependencies:
-      '@glimmer/component': 1.1.2_@babel+core@7.20.12
-      '@glint/config': 0.9.7
-      '@glint/template': 0.9.7_@glimmer+component@1.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@glint/environment-ember-loose/0.9.7_t5ycb63yys2yccfcq5mlxlwezm:
     resolution: {integrity: sha512-MlCGZtB1Clp4vQWIm2APSnCm7nL8wVhFMOhVy2qzpV0nfLyg3pcN9CQHNpfdJvCydBB72cA4/ahPj7VEFL6xsg==}
     peerDependencies:
@@ -2411,6 +2393,26 @@ packages:
       '@glint/config': 0.9.7
       '@glint/template': 0.9.7_@glimmer+component@1.1.2
       ember-cli-htmlbars: 6.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@glint/environment-ember-loose/0.9.7_tgsz7vcw3ssws4mirvv5ovlu7q:
+    resolution: {integrity: sha512-MlCGZtB1Clp4vQWIm2APSnCm7nL8wVhFMOhVy2qzpV0nfLyg3pcN9CQHNpfdJvCydBB72cA4/ahPj7VEFL6xsg==}
+    peerDependencies:
+      '@glimmer/component': ^1.1.2
+      ember-cli-htmlbars: ^6.0.1
+      ember-modifier: ^3.2.7
+    peerDependenciesMeta:
+      ember-cli-htmlbars:
+        optional: true
+      ember-modifier:
+        optional: true
+    dependencies:
+      '@glimmer/component': 1.1.2_@babel+core@7.20.12
+      '@glint/config': 0.9.7
+      '@glint/template': 0.9.7_@glimmer+component@1.1.2
+      ember-modifier: 4.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6214,7 +6216,6 @@ packages:
       silent-error: 1.1.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /ember-cli-path-utils/1.0.0:
     resolution: {integrity: sha512-Qq0vvquzf4cFHoDZavzkOy3Izc893r/5spspWgyzLCPTaG78fM3HsrjZm7UWEltbXUqwHHYrqZd/R0jS08NqSA==}
@@ -6242,7 +6243,6 @@ packages:
 
   /ember-cli-string-utils/1.1.0:
     resolution: {integrity: sha512-PlJt4fUDyBrC/0X+4cOpaGCiMawaaB//qD85AXmDRikxhxVzfVdpuoec02HSiTGTTB85qCIzWBIh8lDOiMyyFg==}
-    dev: true
 
   /ember-cli-terser/4.0.2:
     resolution: {integrity: sha512-Ej77K+YhCZImotoi/CU2cfsoZaswoPlGaM5TB3LvjvPDlVPRhxUHO2RsaUVC5lsGeRLRiHCOxVtoJ6GyqexzFA==}
@@ -6675,6 +6675,21 @@ packages:
       - '@babel/core'
       - supports-color
     dev: true
+
+  /ember-modifier/4.0.0:
+    resolution: {integrity: sha512-OdconmrqKP2haK4kBwNmtnA2NiC2MFmIJC3LgJ1WhwZ49GaktM+bRIuFxF/S5W0oaegzKs1qH2ZDlqMeO2L3nw==}
+    engines: {node: 14.* || 16.* || >= 18}
+    peerDependencies:
+      ember-source: '*'
+    peerDependenciesMeta:
+      ember-source:
+        optional: true
+    dependencies:
+      '@embroider/addon-shim': 1.8.4
+      ember-cli-normalize-entity-name: 1.0.0
+      ember-cli-string-utils: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   /ember-page-title/7.0.0:
     resolution: {integrity: sha512-oq6+HYbeVD/BnxIO5AkP4gWlsatdgW2HFO10F8+XQiJZrwa7cC7Wm54JNGqQkavkDQTgNSiy1Fe2NILJ14MmAg==}

--- a/test-app/tests/integration/components/headless-form-custom-controls-test.gts
+++ b/test-app/tests/integration/components/headless-form-custom-controls-test.gts
@@ -1,0 +1,92 @@
+/* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
+/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
+
+import { tracked } from '@glimmer/tracking';
+import { blur, click, fillIn, render, rerender } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { on } from '@ember/modifier';
+
+import HeadlessForm from 'ember-headless-form/components/headless-form';
+import sinon from 'sinon';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+import type { RenderingTestContext } from '@ember/test-helpers';
+import type {
+  FormValidateCallback,
+  FieldValidateCallback,
+  ErrorRecord,
+  ValidationError,
+} from 'ember-headless-form/components/-private/types';
+
+module(
+  'Integration Component HeadlessForm > Custom Controls',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    interface TestFormData {
+      date?: Date;
+    }
+
+    const days = new Array(31).fill(0).map((_v, index) => index + 1);
+    const months = new Array(12).fill(0).map((_v, index) => index + 1);
+    const years = new Array(20).fill(0).map((_v, index) => index + 2023);
+    const CustomDateControl = <template>
+      <fieldset>
+        <legend>Date</legend>
+        <label for="date-day">Day:</label>
+        <select id="date-day" data-test-day>
+          {{#each days as |day|}}
+            <option value="{{day}}">{{day}}</option>
+          {{/each}}
+        </select>
+        <label for="date-month">Month:</label>
+        <select id="date-month" data-test-month>
+          {{#each months as |month|}}
+            <option value="{{month}}">{{month}}</option>
+          {{/each}}
+        </select>
+        <label for="date-year">Year:</label>
+        <select id="date-year" data-test-year>
+          {{#each years as |year|}}
+            <option value="{{year}}">{{year}}</option>
+          {{/each}}
+        </select>
+      </fieldset>
+    </template>;
+
+    test('triggerValidation allows wiring up arbitrary triggers for validation', async function (assert) {
+      const data: TestFormData = {};
+      const validateCallback = sinon.fake.returns([
+        { type: 'invalid-date', value: undefined, message: 'Invalid Date!' },
+      ]);
+
+      await render(<template>
+        <HeadlessForm @data={{data}} as |form|>
+          <form.field @name="date" @validate={{validateCallback}} as |field|>
+            <CustomDateControl />
+            <button
+              type="button"
+              {{on "click" field.triggerValidation}}
+              data-test-validate
+            >
+              Validate now!
+            </button>
+            <field.errors data-test-date-errors />
+          </form.field>
+          <button type="submit" data-test-submit>Submit</button>
+        </HeadlessForm>
+      </template>);
+
+      await click('[data-test-validate]');
+
+      assert.true(
+        validateCallback.calledWith(undefined, 'date', data),
+        '@validate is called with form data'
+      );
+
+      assert
+        .dom('[data-test-date-errors]')
+        .exists({ count: 1 }, 'validation errors appear when validation fails');
+    });
+  }
+);

--- a/test-app/tests/integration/components/headless-form-custom-controls-test.gts
+++ b/test-app/tests/integration/components/headless-form-custom-controls-test.gts
@@ -1,22 +1,14 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
 /* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
 
-import { tracked } from '@glimmer/tracking';
-import { blur, click, fillIn, render, rerender } from '@ember/test-helpers';
+import { blur, focus, click, render, triggerEvent } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { on } from '@ember/modifier';
 
 import HeadlessForm from 'ember-headless-form/components/headless-form';
 import sinon from 'sinon';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-
-import type { RenderingTestContext } from '@ember/test-helpers';
-import type {
-  FormValidateCallback,
-  FieldValidateCallback,
-  ErrorRecord,
-  ValidationError,
-} from 'ember-headless-form/components/-private/types';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 module(
   'Integration Component HeadlessForm > Custom Controls',
@@ -30,23 +22,26 @@ module(
     const days = new Array(31).fill(0).map((_v, index) => index + 1);
     const months = new Array(12).fill(0).map((_v, index) => index + 1);
     const years = new Array(20).fill(0).map((_v, index) => index + 2023);
-    const CustomDateControl = <template>
-      <fieldset>
+
+    const CustomDateControl: TemplateOnlyComponent<{
+      Element: HTMLFieldSetElement;
+    }> = <template>
+      <fieldset ...attributes>
         <legend>Date</legend>
         <label for="date-day">Day:</label>
-        <select id="date-day" data-test-day>
+        <select id="date-day" data-test-custom-date-control-day>
           {{#each days as |day|}}
             <option value="{{day}}">{{day}}</option>
           {{/each}}
         </select>
         <label for="date-month">Month:</label>
-        <select id="date-month" data-test-month>
+        <select id="date-month" data-test-custom-date-control-month>
           {{#each months as |month|}}
             <option value="{{month}}">{{month}}</option>
           {{/each}}
         </select>
         <label for="date-year">Year:</label>
-        <select id="date-year" data-test-year>
+        <select id="date-year" data-test-custom-date-control-year>
           {{#each years as |year|}}
             <option value="{{year}}">{{year}}</option>
           {{/each}}
@@ -87,6 +82,126 @@ module(
       assert
         .dom('[data-test-date-errors]')
         .exists({ count: 1 }, 'validation errors appear when validation fails');
+    });
+
+    module('captureEvents', function () {
+      test('captures blur events triggering validation without controls having name matching field name when @validateOn="blur"', async function (assert) {
+        const data: TestFormData = {};
+        const validateCallback = sinon.fake.returns([
+          { type: 'invalid-date', value: undefined, message: 'Invalid Date!' },
+        ]);
+
+        await render(<template>
+          <HeadlessForm @data={{data}} @validateOn="blur" as |form|>
+            <form.field @name="date" @validate={{validateCallback}} as |field|>
+              <CustomDateControl {{field.captureEvents}} />
+              <field.errors data-test-date-errors />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
+
+        // the select that triggers the blur does *not* have a name that would allow headless-form to understand from which field this event is coming from
+        // but applying {{captureEvents}} will make headless-form be able to assiciate it to the name of the field
+        await focus('[data-test-custom-date-control-day');
+        await blur('[data-test-custom-date-control-day');
+
+        assert.true(
+          validateCallback.calledWith(undefined, 'date', data),
+          '@validate is called with form data'
+        );
+
+        assert
+          .dom('[data-test-date-errors]')
+          .exists(
+            { count: 1 },
+            'validation errors appear when validation fails'
+          );
+      });
+
+      test('captures change events triggering validation without controls having name matching field name when @validateOn="change"', async function (assert) {
+        const data: TestFormData = {};
+        const validateCallback = sinon.fake.returns([
+          { type: 'invalid-date', value: undefined, message: 'Invalid Date!' },
+        ]);
+
+        await render(<template>
+          <HeadlessForm @data={{data}} @validateOn="change" as |form|>
+            <form.field @name="date" @validate={{validateCallback}} as |field|>
+              <CustomDateControl {{field.captureEvents}} />
+              <field.errors data-test-date-errors />
+            </form.field>
+            <button type="submit" data-test-submit>Submit</button>
+          </HeadlessForm>
+        </template>);
+
+        // the select that triggers the blur does *not* have a name that would allow headless-form to understand from which field this event is coming from
+        // but applying {{captureEvents}} will make headless-form be able to assiciate it to the name of the field
+        await triggerEvent('[data-test-custom-date-control-day', 'change');
+
+        assert.true(
+          validateCallback.calledWith(undefined, 'date', data),
+          '@validate is called with form data'
+        );
+
+        assert
+          .dom('[data-test-date-errors]')
+          .exists(
+            { count: 1 },
+            'validation errors appear when validation fails'
+          );
+      });
+    });
+
+    test('captures blur/change events triggering re-/validation without controls having name matching field name when @validateOn="blur" and @revalidateOn="change"', async function (assert) {
+      const data: TestFormData = {};
+      const validateCallback = sinon.fake.returns([
+        { type: 'invalid-date', value: undefined, message: 'Invalid Date!' },
+      ]);
+
+      await render(<template>
+        <HeadlessForm
+          @data={{data}}
+          @validateOn="blur"
+          @revalidateOn="change"
+          as |form|
+        >
+          <form.field @name="date" @validate={{validateCallback}} as |field|>
+            <CustomDateControl {{field.captureEvents}} />
+            <field.errors data-test-date-errors />
+          </form.field>
+          <button type="submit" data-test-submit>Submit</button>
+        </HeadlessForm>
+      </template>);
+
+      await triggerEvent('[data-test-custom-date-control-day', 'change');
+
+      assert.false(
+        validateCallback.called,
+        '@validate is not called until blur'
+      );
+      assert
+        .dom('[data-test-date-errors]')
+        .doesNotExist('validation errors do not exist until blur');
+
+      await focus('[data-test-custom-date-control-day');
+      await blur('[data-test-custom-date-control-day');
+
+      assert.true(
+        validateCallback.calledWith(undefined, 'date', data),
+        '@validate is called with form data'
+      );
+
+      assert
+        .dom('[data-test-date-errors]')
+        .exists({ count: 1 }, 'validation errors appear when validation fails');
+
+      await triggerEvent('[data-test-custom-date-control-day', 'change');
+
+      assert.true(
+        validateCallback.calledTwice,
+        '@validate is called again on change for revalidation, after initial validation has happened'
+      );
     });
   }
 );


### PR DESCRIPTION
This extends the yielded data from `form.field` to better support integrating custom controls:
* `errorId`: matches the `id` of the yielded `field.errors`, so can be used for `aria-errormessage` (or `aria-describedby`) of the control. See also [this test](https://github.com/CrowdStrike/ember-headless-form/compare/validation-custom-controls?expand=1#diff-f6e04b265c8dedd24dfc797e25b9e48b76e35ab387098d01e70e14c75c10ef10R139-R178)
* `isInvalid`: reflects the validation state of the given field. Can be used to set `aria-invalid`. See also [this test](https://github.com/CrowdStrike/ember-headless-form/compare/validation-custom-controls?expand=1#diff-f6e04b265c8dedd24dfc797e25b9e48b76e35ab387098d01e70e14c75c10ef10R109-R137)
* `triggerValidation`: Gives you the superpowers to trigger validation explicitly for _this field_, whenever you want that to happen. Compare to the discussions in #24, especially "option 2" in https://github.com/CrowdStrike/ember-headless-form/pull/24#issue-1560213454. See also [this test](https://github.com/CrowdStrike/ember-headless-form/compare/validation-custom-controls?expand=1#diff-f6e04b265c8dedd24dfc797e25b9e48b76e35ab387098d01e70e14c75c10ef10R180-R223)
* `captureEvents`: A modifier to see `focusout`/`change` events bubbling up from the control, which are supposed to trigger validation. Will cover the cases where our out-of-the-box handling of events will not be able to determine which field this came from (as the control didn't have a matching `name`). This is basically "option 4" discussed in https://github.com/CrowdStrike/ember-headless-form/pull/24#issuecomment-1407371222. See also [these tests](https://github.com/CrowdStrike/ember-headless-form/compare/validation-custom-controls?expand=1#diff-f6e04b265c8dedd24dfc797e25b9e48b76e35ab387098d01e70e14c75c10ef10R225-R379)

Besides the test coverage for these _new_ features, the new test module also covers some existing cases, which already have tests (e.g. yielding `value`/`setValue`), but it made to sense to me to cover all the different cases of custom controls integration in a single test module, so it can also serve as some kind of preliminary documentation.

Closes #27 