### PR TITLE
Add opt-in `@dataMode="mutable"`

### DIFF
--- a/packages/ember-headless-form/src/components/-private/field.ts
+++ b/packages/ember-headless-form/src/components/-private/field.ts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
-import { action } from '@ember/object';
+import { action, get } from '@ember/object';
 
 import CaptureEventsModifier from './capture-events';
 import CheckboxComponent from './control/checkbox';
@@ -123,7 +123,8 @@ export default class HeadlessFormFieldComponent<
   }
 
   get value(): DATA[KEY] {
-    return this.args.data[this.args.name];
+    // when @mutableData is set, data is something we don't control, i.e. might require old-school get() to be on the safe side
+    return get(this.args.data, this.args.name) as DATA[KEY];
   }
 
   get errors(): ValidationError<DATA[KEY]>[] | undefined {

--- a/packages/ember-headless-form/src/components/-private/field.ts
+++ b/packages/ember-headless-form/src/components/-private/field.ts
@@ -111,6 +111,11 @@ export default class HeadlessFormFieldComponent<
   ) {
     super(owner, args);
 
+    assert(
+      'Nested property paths in @name are not supported.',
+      typeof this.args.name !== 'string' || !this.args.name.includes('.')
+    );
+
     this.args.registerField(this.args.name, {
       validate: this.args.validate,
     });
@@ -124,6 +129,7 @@ export default class HeadlessFormFieldComponent<
 
   get value(): DATA[KEY] {
     // when @mutableData is set, data is something we don't control, i.e. might require old-school get() to be on the safe side
+    // we do not want to support nested property paths for now though, see the constructor assertion!
     return get(this.args.data, this.args.name) as DATA[KEY];
   }
 

--- a/packages/ember-headless-form/src/components/headless-form.ts
+++ b/packages/ember-headless-form/src/components/headless-form.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { assert, warn } from '@ember/debug';
 import { on } from '@ember/modifier';
-import { action } from '@ember/object';
+import { action, set } from '@ember/object';
 import { waitFor } from '@ember/test-waiters';
 
 import { modifier } from 'ember-modifier';
@@ -34,6 +34,7 @@ export interface HeadlessFormComponentSignature<DATA extends UserData> {
   Element: HTMLFormElement;
   Args: {
     data?: DATA;
+    mutableData?: boolean;
     validateOn?: ValidateOn;
     revalidateOn?: ValidateOn;
     validate?: FormValidateCallback<FormData<DATA>>;
@@ -102,7 +103,10 @@ export default class HeadlessFormComponent<
   /**
    * A copy of the passed `@data` stored internally, which is only passed back to the component consumer after a (successful) form submission.
    */
-  internalData: DATA = new TrackedObject(this.args.data ?? {}) as DATA;
+  internalData: DATA =
+    this.args.mutableData && this.args.data
+      ? this.args.data
+      : (new TrackedObject(this.args.data ?? {}) as DATA);
 
   fields = new Map<FormKey<FormData<DATA>>, FieldData<FormData<DATA>>>();
 
@@ -320,7 +324,8 @@ export default class HeadlessFormComponent<
 
   @action
   set<KEY extends FormKey<FormData<DATA>>>(key: KEY, value: DATA[KEY]): void {
-    this.internalData[key] = value;
+    // when @mutableData is set, our internalData is something we don't control, i.e. might require old-school set() to be on the safe side
+    set(this.internalData, key, value);
   }
 
   /**

--- a/packages/ember-headless-form/src/components/headless-form.ts
+++ b/packages/ember-headless-form/src/components/headless-form.ts
@@ -34,7 +34,7 @@ export interface HeadlessFormComponentSignature<DATA extends UserData> {
   Element: HTMLFormElement;
   Args: {
     data?: DATA;
-    mutableData?: boolean;
+    dataMode?: 'mutable' | 'immutable';
     validateOn?: ValidateOn;
     revalidateOn?: ValidateOn;
     validate?: FormValidateCallback<FormData<DATA>>;
@@ -104,7 +104,7 @@ export default class HeadlessFormComponent<
    * A copy of the passed `@data` stored internally, which is only passed back to the component consumer after a (successful) form submission.
    */
   internalData: DATA =
-    this.args.mutableData && this.args.data
+    this.args.dataMode == 'mutable' && this.args.data
       ? this.args.data
       : (new TrackedObject(this.args.data ?? {}) as DATA);
 

--- a/test-app/tests/integration/components/headless-form-data-test.gts
+++ b/test-app/tests/integration/components/headless-form-data-test.gts
@@ -276,4 +276,63 @@ module('Integration Component HeadlessForm > Data', function (hooks) {
       assert.dom('input[data-test-first-name]').hasValue('Nicole');
     });
   });
+  module('@mutableData', function () {
+    test('mutates passed @data when form fields are updated', async function (assert) {
+      const data = { firstName: 'Tony', lastName: 'Ward' };
+
+      await render(<template>
+        <HeadlessForm @data={{data}} @mutableData={{true}} as |form|>
+          <form.field @name="firstName" as |field|>
+            <field.label>First Name</field.label>
+            <field.input data-test-first-name />
+          </form.field>
+          <form.field @name="lastName" as |field|>
+            <field.label>Last Name</field.label>
+            <field.input data-test-last-name />
+          </form.field>
+        </HeadlessForm>
+      </template>);
+
+      await fillIn('input[data-test-first-name]', 'Preston');
+      assert.dom('input[data-test-first-name]').hasValue('Preston');
+      assert.strictEqual(
+        data.firstName,
+        'Preston',
+        'data object is mutated after entering data'
+      );
+    });
+
+    test('@onSubmit is called with same instance of @data', async function (assert) {
+      const data = { firstName: 'Tony', lastName: 'Ward' };
+      const submitHandler = sinon.spy();
+
+      await render(<template>
+        <HeadlessForm
+          @data={{data}}
+          @mutableData={{true}}
+          @onSubmit={{submitHandler}}
+          as |form|
+        >
+          <form.field @name="firstName" as |field|>
+            <field.label>First Name</field.label>
+            <field.input data-test-first-name />
+          </form.field>
+          <form.field @name="lastName" as |field|>
+            <field.label>Last Name</field.label>
+            <field.input data-test-last-name />
+          </form.field>
+          <button type="submit" data-test-submit>Submit</button>
+        </HeadlessForm>
+      </template>);
+
+      await fillIn('input[data-test-first-name]', 'Preston');
+      await click('[data-test-submit]');
+
+      assert.strictEqual(
+        submitHandler.firstCall.firstArg,
+        data,
+        '@OnSubmit is called with same instance of @data, not a copy'
+      );
+    });
+  });
 });

--- a/test-app/tests/integration/components/headless-form-data-test.gts
+++ b/test-app/tests/integration/components/headless-form-data-test.gts
@@ -276,12 +276,12 @@ module('Integration Component HeadlessForm > Data', function (hooks) {
       assert.dom('input[data-test-first-name]').hasValue('Nicole');
     });
   });
-  module('@mutableData', function () {
+  module('@dataMode="mutable"', function () {
     test('mutates passed @data when form fields are updated', async function (assert) {
       const data = { firstName: 'Tony', lastName: 'Ward' };
 
       await render(<template>
-        <HeadlessForm @data={{data}} @mutableData={{true}} as |form|>
+        <HeadlessForm @data={{data}} @dataMode="mutable" as |form|>
           <form.field @name="firstName" as |field|>
             <field.label>First Name</field.label>
             <field.input data-test-first-name />
@@ -309,7 +309,7 @@ module('Integration Component HeadlessForm > Data', function (hooks) {
       await render(<template>
         <HeadlessForm
           @data={{data}}
-          @mutableData={{true}}
+          @dataMode="mutable"
           @onSubmit={{submitHandler}}
           as |form|
         >


### PR DESCRIPTION
Currently the form behaves as a good Ember citizen by strictly following DDAU, i.e. not mutating anything it receives as arguments, especially `@data`. Internally it maintains a copy of that (`internalData`), being passed back to the user only `@onSubmit`.

But there are cases were mutation is needed (or maybe wanted, not so uncommon with forms), especially when that copy-behaviour is provided elsewhere, like with a `changeset` or other buffer/proxy solutions (e.g. https://github.com/yapplabs/ember-buffered-proxy). 

Specifically for #11 we will need to mutate the changeset to make the changeset-validations works, which live on the changeset itself.