### PR TITLE
Add ember-a11y-testing

### DIFF
--- a/.changeset/lovely-hotels-try.md
+++ b/.changeset/lovely-hotels-try.md
@@ -1,0 +1,5 @@
+---
+'ember-headless-form': patch
+---
+
+Add `ember-a11y-testing`

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
         "ember-cli-htmlbars": "required by ember-tracked-storage-polyfill and tracked-built-ins: solution convert to babel plugin?",
         "@babel/core": "See https://github.com/embroider-build/addon-blueprint/pull/77"
       }
+    },
+    "patchedDependencies": {
+      "ember-a11y-testing@5.2.0": "patches/ember-a11y-testing@5.2.0.patch"
     }
   },
   "volta": {

--- a/patches/ember-a11y-testing@5.2.0.patch
+++ b/patches/ember-a11y-testing@5.2.0.patch
@@ -1,0 +1,9 @@
+diff --git a/test-support/setup-middleware-reporter.d.ts b/test-support/setup-middleware-reporter.d.ts
+index 947f3d5a5e92a4238f115a586bf552b34c97ab10..4360fcea65b4e6a1802ff60fb095c61d572ab413 100644
+--- a/test-support/setup-middleware-reporter.d.ts
++++ b/test-support/setup-middleware-reporter.d.ts
+@@ -1,4 +1,3 @@
+-/// <reference types="ember__test-helpers" />
+ import { currentRouteName } from '@ember/test-helpers';
+ import { AxeResults, Result } from 'axe-core';
+ export interface TestMetadata {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ overrides:
 
 patchedDependencies:
   ember-a11y-testing@5.2.0:
-    hash: oqqpvsqtv442p3f53fl7gppdq4
+    hash: ynlyhbi6rwlli5mc64kgdri6jy
     path: patches/ember-a11y-testing@5.2.0.patch
 
 importers:
@@ -461,7 +461,7 @@ importers:
       babel-eslint: 10.1.0_eslint@7.32.0
       broccoli-asset-rev: 3.0.0
       concurrently: 7.6.0
-      ember-a11y-testing: 5.2.0_oqqpvsqtv442p3f53fl7gppdq4_xxksirw4yhzqkev2rkehjstyum
+      ember-a11y-testing: 5.2.0_ynlyhbi6rwlli5mc64kgdri6jy_xxksirw4yhzqkev2rkehjstyum
       ember-auto-import: 2.5.0_webpack@5.75.0
       ember-changeset: 4.1.2_bnlywo5dnzz6qpynghcv26asqa
       ember-cli: 4.10.0-beta.0
@@ -2866,7 +2866,7 @@ packages:
     peerDependencies:
       '@glimmer/component': ^1.1.2
     dependencies:
-      '@glimmer/component': 1.1.2
+      '@glimmer/component': 1.1.2_@babel+core@7.20.12
     dev: true
 
   /@glint/transform/0.9.7:
@@ -6642,7 +6642,7 @@ packages:
   /electron-to-chromium/1.4.284:
     resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
 
-  /ember-a11y-testing/5.2.0_oqqpvsqtv442p3f53fl7gppdq4_xxksirw4yhzqkev2rkehjstyum:
+  /ember-a11y-testing/5.2.0_ynlyhbi6rwlli5mc64kgdri6jy_xxksirw4yhzqkev2rkehjstyum:
     resolution: {integrity: sha512-dWU3+ADTL7gnm+zxFL238OZJpGvLGRGEy07Zxgd64mNIdfNYYPeXOVZ6wjKUIuDXlKzvEnrwHV9D/pcj2rq9UA==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,11 @@ lockfileVersion: 5.4
 overrides:
   '@types/eslint': ^7.0.0
 
+patchedDependencies:
+  ember-a11y-testing@5.2.0:
+    hash: oqqpvsqtv442p3f53fl7gppdq4
+    path: patches/ember-a11y-testing@5.2.0.patch
+
 importers:
 
   .:
@@ -365,6 +370,7 @@ importers:
       babel-eslint: ^10.1.0
       broccoli-asset-rev: ^3.0.0
       concurrently: ^7.6.0
+      ember-a11y-testing: ^5.2.0
       ember-auto-import: ^2.5.0
       ember-changeset: ^4.1.2
       ember-cli: ~4.10.0-beta.0
@@ -455,6 +461,7 @@ importers:
       babel-eslint: 10.1.0_eslint@7.32.0
       broccoli-asset-rev: 3.0.0
       concurrently: 7.6.0
+      ember-a11y-testing: 5.2.0_oqqpvsqtv442p3f53fl7gppdq4_xxksirw4yhzqkev2rkehjstyum
       ember-auto-import: 2.5.0_webpack@5.75.0
       ember-changeset: 4.1.2_bnlywo5dnzz6qpynghcv26asqa
       ember-cli: 4.10.0-beta.0
@@ -2859,7 +2866,7 @@ packages:
     peerDependencies:
       '@glimmer/component': ^1.1.2
     dependencies:
-      '@glimmer/component': 1.1.2_@babel+core@7.20.12
+      '@glimmer/component': 1.1.2
     dev: true
 
   /@glint/transform/0.9.7:
@@ -3118,6 +3125,18 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 2.79.1
+    dev: true
+
+  /@scalvert/ember-setup-middleware-reporter/0.1.1:
+    resolution: {integrity: sha512-C5DHU6YlKaISB5utGQ+jpsMB57ZtY0uZ8UkD29j855BjqG6eJ98lhA2h/BoJbyPw89RKLP1EEXroy9+5JPoyVw==}
+    engines: {node: 12.* || >= 14}
+    dependencies:
+      '@types/fs-extra': 9.0.13
+      body-parser: 1.20.1
+      errorhandler: 1.5.1
+      fs-extra: 10.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@simple-dom/interface/1.4.0:
@@ -3691,6 +3710,12 @@ packages:
 
   /@types/fs-extra/8.1.2:
     resolution: {integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==}
+    dependencies:
+      '@types/node': 18.11.18
+    dev: true
+
+  /@types/fs-extra/9.0.13:
+    resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
       '@types/node': 18.11.18
     dev: true
@@ -4511,6 +4536,11 @@ packages:
   /available-typed-arrays/1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
+
+  /axe-core/4.6.3:
+    resolution: {integrity: sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==}
+    engines: {node: '>=4'}
+    dev: true
 
   /babel-eslint/10.1.0_eslint@7.32.0:
     resolution: {integrity: sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==}
@@ -6612,6 +6642,37 @@ packages:
   /electron-to-chromium/1.4.284:
     resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
 
+  /ember-a11y-testing/5.2.0_oqqpvsqtv442p3f53fl7gppdq4_xxksirw4yhzqkev2rkehjstyum:
+    resolution: {integrity: sha512-dWU3+ADTL7gnm+zxFL238OZJpGvLGRGEy07Zxgd64mNIdfNYYPeXOVZ6wjKUIuDXlKzvEnrwHV9D/pcj2rq9UA==}
+    engines: {node: 12.* || 14.* || >= 16}
+    peerDependencies:
+      '@ember/test-helpers': ^2.0.0
+      qunit: '>= 2'
+    peerDependenciesMeta:
+      qunit:
+        optional: true
+    dependencies:
+      '@ember/test-helpers': 2.9.3_ember-source@4.10.0
+      '@ember/test-waiters': 3.0.2
+      '@scalvert/ember-setup-middleware-reporter': 0.1.1
+      axe-core: 4.6.3
+      body-parser: 1.20.1
+      broccoli-persistent-filter: 3.1.3
+      ember-auto-import: 2.5.0_webpack@5.75.0
+      ember-cli-babel: 7.26.11
+      ember-cli-typescript: 4.2.1
+      ember-cli-version-checker: 5.1.2
+      ember-destroyable-polyfill: 2.0.3
+      fs-extra: 10.1.0
+      qunit: 2.19.3
+      validate-peer-dependencies: 2.1.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+      - webpack
+    dev: true
+    patched: true
+
   /ember-auto-import/2.5.0:
     resolution: {integrity: sha512-fKERUmpZLn4RJiCwTjS7D5zJxgnbF4E6GiSp1GYh53K96S+5UBs06r7ScDI52rq34z0+qdSrA6qiDJ3i/lWqKg==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -7765,6 +7826,14 @@ packages:
     resolution: {integrity: sha512-fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==}
     dependencies:
       string-template: 0.2.1
+    dev: true
+
+  /errorhandler/1.5.1:
+    resolution: {integrity: sha512-rcOwbfvP1WTViVoUjcfZicVzjhjTuhSMntHh6mW3IrEiyE6mJyXvsToJUJGlGlw/2xU9P5whlWNGlIDVeCiT4A==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      accepts: 1.3.8
+      escape-html: 1.0.3
     dev: true
 
   /es-abstract/1.21.1:

--- a/test-app/app/controllers/index.ts
+++ b/test-app/app/controllers/index.ts
@@ -1,13 +1,16 @@
 import Controller from '@ember/controller';
 
 interface MyFormData {
-  name: string;
+  firstName?: string;
+  lastName?: string;
+  gender?: 'male' | 'female' | 'other';
+  email?: string;
+  accept_tos?: boolean;
+  comment?: string;
 }
 
 export default class IndexController extends Controller {
-  data: MyFormData = {
-    name: 'Simon',
-  };
+  data: MyFormData = {};
 
   doSomething(data: MyFormData) {
     // eslint-disable-next-line no-console

--- a/test-app/app/index.html
+++ b/test-app/app/index.html
@@ -8,6 +8,7 @@
 
     {{content-for "head"}}
 
+    <script src="https://cdn.tailwindcss.com"></script>
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/test-app.css" />
 

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -1,5 +1,7 @@
 {{page-title 'TestApp'}}
 
-<h2 id='title'>Welcome to Headless Forms!</h2>
+<div class='max-w-md mx-auto'>
+  <h2 class='text-2xl my-8' id='title'>Welcome to Headless Forms!</h2>
 
-{{outlet}}
+  {{outlet}}
+</div>

--- a/test-app/app/templates/index.hbs
+++ b/test-app/app/templates/index.hbs
@@ -5,12 +5,81 @@
   @onSubmit={{this.doSomething}}
   as |form|
 >
-  <form.field @name='name' as |field|>
-    <field.label>Name</field.label>
-    <field.input required />
-    <field.errors />
+  <form.field @name='firstName' as |field|>
+    <div class='my-2 flex flex-col'>
+      <field.label class={{if field.isInvalid 'text-red-500'}}>First name</field.label>
+      <field.input
+        class='border rounded px-2 {{if field.isInvalid "border-red-500"}}'
+        required
+      />
+      <field.errors class='text-red-600' />
+    </div>
   </form.field>
 
-  <button type='submit'>Submit</button>
-  {{! <form.submitButton>Submit</form.submitButton> }}
+  <form.field @name='lastName' as |field|>
+    <div class='my-2 flex flex-col'>
+      <field.label class={{if field.isInvalid 'text-red-500'}}>Last name</field.label>
+      <field.input
+        class='border rounded px-2 {{if field.isInvalid "border-red-500"}}'
+        required
+      />
+      <field.errors class='text-red-600' />
+    </div>
+  </form.field>
+
+  <form.field @name='gender' as |field|>
+    <div class='my-2 flex flex-col'>
+      Gender:
+      <div class='flex flex-row space-x-2'>
+        <field.radio @value='male' as |radio|>
+          <radio.input />
+          <radio.label>Male</radio.label>
+        </field.radio>
+        <field.radio @value='female' as |radio|>
+          <radio.input />
+          <radio.label>Female</radio.label>
+        </field.radio>
+        <field.radio @value='other' as |radio|>
+          <radio.input />
+          <radio.label>Other</radio.label>
+        </field.radio>
+      </div>
+    </div>
+  </form.field>
+
+  <form.field @name='email' as |field|>
+    <div class='my-2 flex flex-col'>
+      <field.label
+        class={{if field.isInvalid 'text-red-500'}}
+      >Email</field.label>
+      <field.input
+        class='border rounded px-2 {{if field.isInvalid "border-red-500"}}'
+        @type='email'
+        required
+      />
+      <field.errors class='text-red-600' />
+    </div>
+  </form.field>
+
+  <form.field @name='comment' as |field|>
+    <div class='my-2 flex flex-col'>
+      <field.label>Comment</field.label>
+      <field.textarea class='border rounded px-2' />
+      <field.errors class='text-red-600' />
+    </div>
+  </form.field>
+
+  <form.field @name='accept_tos' as |field|>
+    <div class='my-2 flex flex-row space-x-2'>
+      <field.checkbox required />
+      <field.label class={{if field.isInvalid 'text-red-500'}}>Accept TOS</field.label>
+      <field.errors class='text-red-600' />
+    </div>
+  </form.field>
+
+  <button
+    type='submit'
+    class='bg-slate-600 text-white rounded px-8 py-1'
+    data-test-submit
+  >Submit</button>
 </HeadlessForm>

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -26,6 +26,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
+    "@ember-headless-form/changeset": "workspace:*",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.8.1",
     "@ember-headless-form/changeset": "workspace:*",
@@ -75,6 +76,7 @@
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^7.6.0",
+    "ember-a11y-testing": "^5.2.0",
     "ember-auto-import": "^2.5.0",
     "ember-changeset": "^4.1.2",
     "ember-cli": "~4.10.0-beta.0",

--- a/test-app/tests/acceptance/a11y-test.ts
+++ b/test-app/tests/acceptance/a11y-test.ts
@@ -1,0 +1,25 @@
+import { click, visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from 'test-app/tests/helpers';
+
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | a11y', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('form passes a11y audit', async function (assert) {
+    await visit('/');
+
+    await a11yAudit();
+    assert.true(true, 'no a11y errors found!');
+  });
+
+  test('form passes a11y audit after validation', async function (assert) {
+    await visit('/');
+    await click('[data-test-submit]');
+
+    await a11yAudit();
+    assert.true(true, 'no a11y errors found!');
+  });
+});


### PR DESCRIPTION
This 
* makes the test-app's dummy form a bit more of a kitchen-sink like example, covering all the different field types we currently have
* adds some basic tailwind-based styling (because: why not?)
* runs `ember-a11y-testing` on it

Closes #20 