### PR TITLE
Tell changeset to do a 1.0.0-beta instead of a 0.0.1-beta

### DIFF
--- a/.changeset/silly-cougars-decide.md
+++ b/.changeset/silly-cougars-decide.md
@@ -1,5 +1,5 @@
 ---
-'ember-headless-form': patch
+'ember-headless-form': major
 ---
 
-Test initial beta release
+Initial release


### PR DESCRIPTION
I noticed over on the release preview: https://github.com/CrowdStrike/ember-headless-form/pull/36

ember-headless-form is still configured as 0.0.1-beta.

This syncs it with the other dependency to 1.0.0-beta

Edit: I see now that https://github.com/CrowdStrike/ember-headless-form/pull/42/files also did a change that would have the same effect 🙃 