### PR TITLE
pnpm i -f must be ran after a build, when using depMea.*.injected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
-      - run: pnpm build
+      - run: pnpm build && pnpm i -f
       # To be able to run glint, we need the dist directory
       # - uses: ./.github/actions/download-built-package
       - name: Lint + Format + Glint
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
       # - uses: ./.github/actions/download-built-package
-      - run: pnpm build
+      - run: pnpm build && pnpm i -f
       - name: 'Change TS to ${{ matrix.typescript-scenario }}'
         run: 'pnpm add --save-dev ${{ matrix.typescript-scenario}}'
         working-directory: ./test-app
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
-      - run: pnpm build
+      - run: pnpm build && pnpm i -f
       # - uses: ./.github/actions/download-built-package
       - run: pnpm --filter test-app test:ember
 
@@ -103,7 +103,7 @@ jobs:
       - uses: ./.github/actions/pnpm
       - name: Install Dependencies (without lockfile)
         run: rm pnpm-lock.yaml && pnpm install
-      - run: pnpm build
+      - run: pnpm build && pnpm i -f
       # - uses: ./.github/actions/download-built-package
       - run: pnpm --filter test-app test:ember
 
@@ -129,7 +129,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
-      - run: pnpm build
+      - run: pnpm build && pnpm i -f
       # - uses: ./.github/actions/download-built-package
       - name: Run Tests
         working-directory: ./test-app
@@ -154,7 +154,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/pnpm
-      - run: pnpm build
+      - run: pnpm build && pnpm i -f
       # - uses: ./.github/actions/download-built-package
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
due to https://github.com/CrowdStrike/ember-headless-form/pull/49#issuecomment-1431309759, 
https://github.com/CrowdStrike/ember-headless-form/pull/45 is no longer viable.

See: https://github.com/pnpm/pnpm/issues/6088