### PR TITLE
Add JS/TSDoc comments

### DIFF
--- a/packages/changeset-validations/src/helpers/validate-changeset.ts
+++ b/packages/changeset-validations/src/helpers/validate-changeset.ts
@@ -8,7 +8,7 @@ import { assert } from '@ember/debug';
  * Validation helper for integrating `ember-changeset` based validations into headless forms:
  *
  * - pass a changeset to the form's `@data`
- * - pass this helper into the form's `@validate` hook
+ * - pass this helper into the form's `@validate` hook `@validate={{validateChangeset}}`
  * - opt-in to `@dataMode="mutable"`
  */
 const validateChangeset: FormValidateCallback<EmberChangeset> = async (

--- a/packages/changeset-validations/src/helpers/validate-changeset.ts
+++ b/packages/changeset-validations/src/helpers/validate-changeset.ts
@@ -4,6 +4,13 @@ import type { ErrorRecord, FormValidateCallback } from 'ember-headless-form';
 import type { EmberChangeset } from 'ember-changeset';
 import { assert } from '@ember/debug';
 
+/**
+ * Validation helper for integrating `ember-changeset` based validations into headless forms:
+ *
+ * - pass a changeset to the form's `@data`
+ * - pass this helper into the form's `@validate` hook
+ * - opt-in to `@dataMode="mutable"`
+ */
 const validateChangeset: FormValidateCallback<EmberChangeset> = async (
   changeset,
   fields

--- a/packages/ember-headless-form/src/-private/components/control/checkbox.ts
+++ b/packages/ember-headless-form/src/-private/components/control/checkbox.ts
@@ -4,11 +4,36 @@ import { action } from '@ember/object';
 export interface HeadlessFormControlCheckboxComponentSignature {
   Element: HTMLInputElement;
   Args: {
+    // the following are private arguments curried by the component helper, so users will never have to use those
+
+    /*
+     * @internal
+     */
     value: boolean;
+
+    /*
+     * @internal
+     */
     name: string;
+
+    /*
+     * @internal
+     */
     fieldId: string;
+
+    /*
+     * @internal
+     */
     setValue: (value: boolean) => void;
+
+    /*
+     * @internal
+     */
     invalid: boolean;
+
+    /*
+     * @internal
+     */
     errorId: string;
   };
 }

--- a/packages/ember-headless-form/src/-private/components/control/input.ts
+++ b/packages/ember-headless-form/src/-private/components/control/input.ts
@@ -3,7 +3,7 @@ import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 
 // Possible values for the input type, see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types
-// for the sake ok completeness, we list all here, with some commented out that are better handled elsewhere, or not at all...
+// for the sake of completeness, we list all here, with some commented out that are better handled elsewhere, or not at all...
 export type InputType =
   // | 'button' - not useful as a control component
   // | 'checkbox' - handled separately, for handling `checked` correctly and operating with true boolean values
@@ -31,12 +31,54 @@ export type InputType =
 export interface HeadlessFormControlInputComponentSignature {
   Element: HTMLInputElement;
   Args: {
-    value: string;
-    name: string;
+    /**
+     * The `type` of the `<input>` element, by default `text`.
+     *
+     * Note that certain types should not be used, as they have dedicated control components:
+     * - `checkbox`
+     * - `radio`
+     *
+     * Also these types are not useful to use as input controls:
+     * - `button`
+     * - `file`
+     * - `image`
+     * - `reset`
+     * - `submit`
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types
+     */
     type?: InputType;
+
+    // the following are private arguments curried by the component helper, so users will never have to use those
+
+    /*
+     * @internal
+     */
+    value: string;
+
+    /*
+     * @internal
+     */
+    name: string;
+
+    /*
+     * @internal
+     */
     fieldId: string;
+
+    /*
+     * @internal
+     */
     setValue: (value: string) => void;
+
+    /*
+     * @internal
+     */
     invalid: boolean;
+
+    /*
+     * @internal
+     */
     errorId: string;
   };
 }

--- a/packages/ember-headless-form/src/-private/components/control/radio.ts
+++ b/packages/ember-headless-form/src/-private/components/control/radio.ts
@@ -9,15 +9,39 @@ import type { ComponentLike, WithBoundArgs } from '@glint/template';
 
 export interface HeadlessFormControlRadioComponentSignature {
   Args: {
+    /**
+     * The value of this individual radio control. All the radios that belong to the same field (have the same name) should have distinct values.
+     */
     value: string;
+
+    // the following are private arguments curried by the component helper, so users will never have to use those
+
+    /*
+     * @internal
+     */
     name: string;
+
+    /*
+     * @internal
+     */
     selected: string;
+
+    /*
+     * @internal
+     */
     setValue: (value: string) => void;
   };
   Blocks: {
     default: [
       {
+        /**
+         * Yielded component that renders the `<label>` of this single radio element.
+         */
         Label: WithBoundArgs<typeof LabelComponent, 'fieldId'>;
+
+        /**
+         * Yielded component that renders the `<input type="radio">` element.
+         */
         Input: WithBoundArgs<
           typeof RadioInputComponent,
           'fieldId' | 'value' | 'setValue' | 'checked' | 'name'

--- a/packages/ember-headless-form/src/-private/components/control/radio/input.ts
+++ b/packages/ember-headless-form/src/-private/components/control/radio/input.ts
@@ -3,10 +3,31 @@ import templateOnlyComponent from '@ember/component/template-only';
 export interface HeadlessFormControlRadioInputComponentSignature {
   Element: HTMLInputElement;
   Args: {
+    // the following are private arguments curried by the component helper, so users will never have to use those
+
+    /*
+     * @internal
+     */
     value: string;
+
+    /*
+     * @internal
+     */
     name: string;
+
+    /*
+     * @internal
+     */
     checked: boolean;
+
+    /*
+     * @internal
+     */
     fieldId: string;
+
+    /*
+     * @internal
+     */
     setValue: (value: string) => void;
   };
 }

--- a/packages/ember-headless-form/src/-private/components/control/textarea.ts
+++ b/packages/ember-headless-form/src/-private/components/control/textarea.ts
@@ -4,11 +4,36 @@ import { action } from '@ember/object';
 export interface HeadlessFormControlTextareaComponentSignature {
   Element: HTMLTextAreaElement;
   Args: {
+    // the following are private arguments curried by the component helper, so users will never have to use those
+
+    /*
+     * @internal
+     */
     value: string;
+
+    /*
+     * @internal
+     */
     name: string;
+
+    /*
+     * @internal
+     */
     fieldId: string;
+
+    /*
+     * @internal
+     */
     setValue: (value: string) => void;
+
+    /*
+     * @internal
+     */
     invalid: boolean;
+
+    /*
+     * @internal
+     */
     errorId: string;
   };
 }

--- a/packages/ember-headless-form/src/-private/components/errors.ts
+++ b/packages/ember-headless-form/src/-private/components/errors.ts
@@ -5,7 +5,16 @@ import type { ValidationError } from '../types';
 export interface HeadlessFormErrorsComponentSignature<VALUE> {
   Element: HTMLDivElement;
   Args: {
+    // the following are private arguments curried by the component helper, so users will never have to use those
+
+    /*
+     * @internal
+     */
     errors: ValidationError<VALUE>[];
+
+    /*
+     * @internal
+     */
     id: string;
   };
   Blocks: {

--- a/packages/ember-headless-form/src/-private/components/field.ts
+++ b/packages/ember-headless-form/src/-private/components/field.ts
@@ -36,47 +36,159 @@ export interface HeadlessFormFieldComponentSignature<
   KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
 > {
   Args: {
-    data: FormData<DATA>;
+    /**
+     * The name of your field, which must match a property of the `@data` passed to the form
+     */
     name: KEY;
-    set: (key: KEY, value: DATA[KEY]) => void;
+
+    /**
+     * Provide a custom validation function, that operates only on this specific field. Eventual validation errors are merged with native validation errors to determine the effective set of errors rendered for the field.
+     *
+     * Return undefined when no validation errors are present, otherwise an array of (one or multiple) `ValidationError`s.
+     */
     validate?: FieldValidateCallback<FormData<DATA>, KEY>;
+
+    // the following are private arguments curried by the component helper, so users will never have to use those
+
+    /*
+     * @internal
+     */
+    data: FormData<DATA>;
+
+    /*
+     * @internal
+     */
+    set: (key: KEY, value: DATA[KEY]) => void;
+
+    /*
+     * @internal
+     */
     errors?: ErrorRecord<DATA, KEY>;
+
+    /*
+     * @internal
+     */
     registerField: RegisterFieldCallback<FormData<DATA>, KEY>;
+
+    /*
+     * @internal
+     */
     unregisterField: UnregisterFieldCallback<FormData<DATA>, KEY>;
+
+    /*
+     * @internal
+     */
     triggerValidationFor(name: KEY): Promise<void>;
+
+    /*
+     * @internal
+     */
     fieldValidationEvent: 'focusout' | 'change' | 'input' | undefined;
+
+    /*
+     * @internal
+     */
     fieldRevalidationEvent: 'focusout' | 'change' | 'input' | undefined;
   };
   Blocks: {
     default: [
       {
+        /**
+         * Yielded component that renders the `<label>` element.
+         */
         Label: WithBoundArgs<typeof LabelComponent, 'fieldId'>;
+
+        /**
+         * Yielded control component that renders an `<input>` element.
+         */
         Input: WithBoundArgs<
           typeof InputComponent,
           'name' | 'fieldId' | 'value' | 'setValue' | 'invalid' | 'errorId'
         >;
+
+        /**
+         * Yielded control component that renders an `<input type="checkbox">` element.
+         */
         Checkbox: WithBoundArgs<
           typeof CheckboxComponent,
           'name' | 'fieldId' | 'value' | 'setValue' | 'invalid' | 'errorId'
         >;
+
+        /**
+         * Yielded control component that renders a single radio control.
+         *
+         * Use multiple to define a radio group. It further yields components to render `Input` and `Label`.
+         */
         Radio: WithBoundArgs<
           typeof RadioComponent,
           'name' | 'selected' | 'setValue'
         >;
+
+        /**
+         * Yielded control component that renders a `<textarea>` element.
+         */
         Textarea: WithBoundArgs<
           typeof TextareaComponent,
           'name' | 'fieldId' | 'value' | 'setValue' | 'invalid' | 'errorId'
         >;
+
+        /**
+         * The current value of the field's form data.
+         *
+         * If you don't use one of the supplied control components, then use this to pass the value to your custom component.
+         */
         value: DATA[KEY];
+
+        /**
+         * Action to update the (internal) form data for this field.
+         *
+         * If you don't use one of the supplied control components, then use this to update the value whenever you custom component's value has changed.
+         */
         setValue: (value: DATA[KEY]) => void;
+
+        /**
+         * Unique ID of this field, used to associate the control with its label.
+         *
+         * If you don't use the supplied components, then you can use this as the `id` of the control and the `for` attribute of the `<label>`.
+         */
         id: string;
+
+        /**
+         * Unique error ID of this field, used to associate the control with its validation error message.
+         *
+         * If you don't use the supplied components, then you can use this as the `id` of the validation error element and the `aria-errormessage` or `aria-describedby` attribute of the control.
+         */
         errorId: string;
+
+        /**
+         * Yielded component that renders all validation error messages if there are any.
+         *
+         * In non-block mode it will render all messages by default. In block-mode, it yields all `ValidationError` objects for you to customize the rendering.
+         */
         errors?: WithBoundArgs<
           typeof ErrorsComponent<DATA[KEY]>,
           'errors' | 'id'
         >;
+
+        /**
+         * Will be `true` when validation was triggered and this field is invalid.
+         *
+         * You can use this to customize your markup, e.g. apply HTML classes for error styling.
+         */
         isInvalid: boolean;
+
+        /**
+         * When calling this action, validation will be triggered.
+         *
+         * Can be used for custom controls that don't emit the `@validateOn` events that would normally trigger a dynamic validation.
+         */
         triggerValidation: () => void;
+
+        /**
+         * Yielded modifier that when applied to the control element or any other element wrapping it will be able to recognize the `@validateOn` events and associate them to this field.
+         *
+         * This is only needed for very special cases, where the control is not a native form control or does not have the `@name` of the field assigned to the `name` attribute of the control.
+         */
         captureEvents: WithBoundArgs<
           ModifierLike<CaptureEventsModifierSignature>,
           'event' | 'triggerValidation'

--- a/packages/ember-headless-form/src/-private/components/field.ts
+++ b/packages/ember-headless-form/src/-private/components/field.ts
@@ -142,7 +142,7 @@ export interface HeadlessFormFieldComponentSignature<
         /**
          * Action to update the (internal) form data for this field.
          *
-         * If you don't use one of the supplied control components, then use this to update the value whenever you custom component's value has changed.
+         * If you don't use one of the supplied control components, then use this to update the value whenever your custom component's value has changed.
          */
         setValue: (value: DATA[KEY]) => void;
 

--- a/packages/ember-headless-form/src/-private/components/label.ts
+++ b/packages/ember-headless-form/src/-private/components/label.ts
@@ -3,6 +3,11 @@ import templateOnlyComponent from '@ember/component/template-only';
 export interface HeadlessFormLabelComponentSignature {
   Element: HTMLLabelElement;
   Args: {
+    // the following are private arguments curried by the component helper, so users will never have to use those
+
+    /*
+     * @internal
+     */
     fieldId: string;
   };
   Blocks: {

--- a/packages/ember-headless-form/src/-private/modifiers/capture-events.ts
+++ b/packages/ember-headless-form/src/-private/modifiers/capture-events.ts
@@ -4,7 +4,14 @@ export interface CaptureEventsModifierSignature {
   Element: HTMLElement;
   Args: {
     Named: {
+      /*
+       * @internal
+       */
       event: 'focusout' | 'change';
+
+      /*
+       * @internal
+       */
       triggerValidation(): void;
     };
   };

--- a/packages/ember-headless-form/src/template-registry.ts
+++ b/packages/ember-headless-form/src/template-registry.ts
@@ -5,5 +5,35 @@
 import type HeadlessFormComponent from './components/headless-form';
 
 export default interface Registry {
+  /**
+   * Headless form component.
+   *
+   * @example
+   * Usage example:
+   *
+   * ```hbs
+   * <HeadlessForm
+   *   @data={{this.data}}
+   *   @validateOn="focusout"
+   *   @revalidateOn="input"
+   *   @onSubmit={{this.doSomething}}
+   *   as |form|
+   * >
+   *   <form.Field @name="firstName" as |field|>
+   *     <div>
+   *       <field.Label>First name</field.Label>
+   *       <field.Input
+   *         required
+   *       />
+   *       <field.errors />
+   *     </div>
+   *   </form.Field>
+   *
+   *   <button
+   *     type="submit"
+   *   >Submit</button>
+   * </HeadlessForm>
+   * ```
+   */
   HeadlessForm: typeof HeadlessFormComponent;
 }

--- a/packages/yup/src/helpers/validate-yup.ts
+++ b/packages/yup/src/helpers/validate-yup.ts
@@ -7,6 +7,11 @@ import { assert } from '@ember/debug';
 
 import type { ObjectSchema, ValidationError } from 'yup';
 
+/**
+ * Validation helper for integrating `yup` based validations into headless forms.
+ *
+ * Pass this to the `@validate` hook, supplying the `yup` schema as the only argument: `@validate={{validateYup schema}}`.
+ */
 export default function validateChangeset<DATA extends object>(
   schema: ObjectSchema<DATA>
 ): FormValidateCallback<Partial<DATA>> {


### PR DESCRIPTION
Gives us nice IntelliSense tooltips in VS Code with Glint:

![image](https://user-images.githubusercontent.com/1325249/219661080-a58d7659-ecce-4626-8520-e9b7569402da.png)

Also enables us to use TypeDoc later for API docs. 

Tried to add https://github.com/hosseinmd/prettier-plugin-jsdoc, but it seems to cause more problems than it solves (messes up code blocks in markdown, also other bugs on its Github issues page)

Closes #38 

