### PR TITLE
Skip canary tests for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,8 @@ jobs:
           - ember-lts-4.8
           - ember-release
           - ember-beta
-          - ember-canary
+          # @todo enable this again: https://github.com/CrowdStrike/ember-headless-form/issues/54
+          # - ember-canary
           - "'ember-lts-4.8 + embroider-safe'"
           - "'ember-lts-4.8 + embroider-optimized'"
           - "'ember-release + embroider-optimized'"


### PR DESCRIPTION
Ember 5.0.0-alpha has _just_ been released, which `canary` is now pointing to. ember-qunit has peerDependency problems failing the build (https://github.com/emberjs/ember-qunit/issues/1026). Other upstream dependencies maybe also. For now skipping canary from the CI matrix to unblock CI. Need to re-enable this, tracking issue: https://github.com/CrowdStrike/ember-headless-form/issues/54