### PR TITLE
Yield async validation and submission state

### DIFF
--- a/docs/usage/async/demo/async.md
+++ b/docs/usage/async/demo/async.md
@@ -1,0 +1,53 @@
+# Async state
+
+Submit this form with a valid email, and with the same email again, to see how it disables the submit button, changes its label, and shows error messages coming from the "backend":
+
+```hbs template
+<HeadlessForm @onSubmit={{this.handleSubmit}} as |form|>
+  <form.Field @name='email' as |field|>
+    <div class='my-2 flex flex-col'>
+      <field.Label>Email</field.Label>
+      <field.Input
+        @type='email'
+        placeholder='Please enter your email'
+        class='border rounded px-2'
+      />
+    </div>
+  </form.Field>
+
+  <button type='submit' disabled={{form.submissionState.isPending}}>
+    {{if form.submissionState.isPending 'Submitting...' 'Submit'}}
+  </button>
+
+  {{#if form.submissionState.isResolved}}
+    <p>We got your data! 🎉</p>
+  {{else if form.submissionState.isRejected}}
+    <p>⛔️ {{form.submissionState.error}}</p>
+  {{/if}}
+</HeadlessForm>
+```
+
+```js component
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class MyFormComponent extends Component {
+  saved = [];
+
+  @action
+  async handleSubmit({ email }) {
+    // pretending something async is happening here
+    await new Promise((r) => setTimeout(r, 3000));
+
+    if (!email) {
+      throw new Error('No email given');
+    }
+
+    if (this.saved.includes(email)) {
+      throw new Error(`${email} is already taken!`);
+    }
+
+    this.saved.push(email);
+  }
+}
+```

--- a/docs/usage/async/demo/async.md
+++ b/docs/usage/async/demo/async.md
@@ -44,6 +44,7 @@ export default class MyFormComponent extends Component {
     }
 
     if (this.saved.includes(email)) {
+      // Throwing this error will cause the form to yield form.submissionState.isRejected as true
       throw new Error(`${email} is already taken!`);
     }
 

--- a/docs/usage/async/index.md
+++ b/docs/usage/async/index.md
@@ -1,0 +1,29 @@
+---
+title: Async state
+order: 6
+---
+
+# Managing asynchronous state
+
+ember-headless-form knows about two events that can be asynchronous:
+
+- **validation** will often be synchronous, but you can also define [asynchronous validations](../../validation/custom-validation.md#asynchronous-validation) for e.g. validating data on the server
+- **submission** is most often asynchronous when e.g. sending a `POST` request with your form data to the server
+
+To make the form aware of the asynchronous submission process, you just need to return a Promise from the submit callback passed to [`@onSubmit`](../data/index.md#getting-data-out).
+
+ember-headless-form will then make the async state of both these events available to you in the template. This allows for use cases like
+
+- disabling the submit button while a submission is ongoing
+- showing a loading indicator while submission or validation is pending
+- rendering the results of the (either successful or failed) submission, after it is resolved/rejected
+
+To enable these, the form component is yielding `validationState` and `submissionState` objects with these properties:
+
+- `isPending`
+- `isResolved`
+- `isRejected`
+- `value` (when resolved)
+- `error` (when rejected)
+
+These derived properties are fully reactive and typed, as these are provided by the excellent [ember-async-data](https://github.com/tracked-tools/ember-async-data) addon. Refer to their documentation for additional details!

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
       }
     },
     "patchedDependencies": {
-      "ember-a11y-testing@5.2.0": "patches/ember-a11y-testing@5.2.0.patch"
+      "ember-a11y-testing@5.2.0": "patches/ember-a11y-testing@5.2.0.patch",
+      "ember-auto-import@2.6.1": "patches/ember-auto-import@2.6.1.patch"
     }
   },
   "volta": {

--- a/packages/ember-headless-form/package.json
+++ b/packages/ember-headless-form/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "@babel/runtime": "^7.20.7",
     "@embroider/addon-shim": "^1.0.0",
-    "@ember/test-waiters": "^3.0.2",
     "@embroider/util": "^1.10.0",
+    "ember-async-data": "^0.7.0",
     "ember-modifier": "^4.1.0",
     "tracked-built-ins": "^3.1.0"
   },

--- a/packages/ember-headless-form/src/components/headless-form.hbs
+++ b/packages/ember-headless-form/src/components/headless-form.hbs
@@ -25,6 +25,7 @@
         fieldValidationEvent=this.fieldValidationEvent
         fieldRevalidationEvent=this.fieldRevalidationEvent
       )
+      validationState=this.validationState
       isInvalid=this.hasValidationErrors
     )
   }}

--- a/packages/ember-headless-form/src/components/headless-form.hbs
+++ b/packages/ember-headless-form/src/components/headless-form.hbs
@@ -26,6 +26,7 @@
         fieldRevalidationEvent=this.fieldRevalidationEvent
       )
       validationState=this.validationState
+      submissionState=this.submissionState
       isInvalid=this.hasValidationErrors
     )
   }}

--- a/packages/ember-headless-form/src/components/headless-form.ts
+++ b/packages/ember-headless-form/src/components/headless-form.ts
@@ -25,7 +25,10 @@ import type { ModifierLike, WithBoundArgs } from '@glint/template';
 
 type ValidateOn = 'change' | 'focusout' | 'submit' | 'input';
 
-export interface HeadlessFormComponentSignature<DATA extends UserData> {
+export interface HeadlessFormComponentSignature<
+  DATA extends UserData,
+  SUBMISSION_VALUE
+> {
   Element: HTMLFormElement;
   Args: {
     /**
@@ -62,7 +65,9 @@ export interface HeadlessFormComponentSignature<DATA extends UserData> {
     /**
      * Called when the user has submitted the form and no validation errors have been determined. Receives the new form data, or in case of `@dataMode="mutable"` the original data object.
      */
-    onSubmit?: (data: FormData<DATA>) => void;
+    onSubmit?: (
+      data: FormData<DATA>
+    ) => SUBMISSION_VALUE | Promise<SUBMISSION_VALUE>;
 
     /**
      * Called when the user tried to submit the form, but validation failed. Receives the new data (or in case of `@dataMode="mutable"` the original data object), and the record of validation errors by field.
@@ -93,9 +98,16 @@ export interface HeadlessFormComponentSignature<DATA extends UserData> {
         /**
          * The (async) validation state as `TrackedAsyncData`.
          *
-         * Use derived state like `.isPending` to conditionally render the UI.
+         * Use derived state like `.isPending` to render the UI conditionally.
          */
-        validationState?: TrackedAsyncData<undefined | ErrorRecord<DATA>>;
+        validationState?: TrackedAsyncData<ErrorRecord<DATA>>;
+
+        /**
+         * The (async) submission state as `TrackedAsyncData`.
+         *
+         * Use derived state like `.isPending` to render the UI conditionally.
+         */
+        submissionState?: TrackedAsyncData<SUBMISSION_VALUE>;
 
         /**
          * Will be true if at least one form field is invalid.
@@ -159,8 +171,9 @@ class FieldData<
  * ```
  */
 export default class HeadlessFormComponent<
-  DATA extends UserData
-> extends Component<HeadlessFormComponentSignature<DATA>> {
+  DATA extends UserData,
+  SUBMISSION_VALUE
+> extends Component<HeadlessFormComponentSignature<DATA, SUBMISSION_VALUE>> {
   FieldComponent = FieldComponent<DATA>;
 
   // we cannot use (modifier "on") directly in the template due to https://github.com/emberjs/ember.js/issues/19869
@@ -183,6 +196,7 @@ export default class HeadlessFormComponent<
   fields = new Map<FormKey<FormData<DATA>>, FieldData<FormData<DATA>>>();
 
   @tracked validationState?: TrackedAsyncData<ErrorRecord<DATA>>;
+  @tracked submissionState?: TrackedAsyncData<SUBMISSION_VALUE>;
 
   /**
    * When this is set to true by submitting the form, eventual validation errors are show for *all* field, regardless of their individual dynamic validation status in `FieldData#validationEnabled`
@@ -376,7 +390,12 @@ export default class HeadlessFormComponent<
     this.showAllValidations = true;
 
     if (!this.hasValidationErrors) {
-      this.args.onSubmit?.(this.internalData);
+      if (this.args.onSubmit) {
+        this.submissionState = new TrackedAsyncData(
+          this.args.onSubmit(this.internalData),
+          this
+        );
+      }
     } else {
       assert(
         'Validation errors expected to be present. If you see this, please report it as a bug to ember-headless-form!',

--- a/patches/ember-auto-import@2.6.1.patch
+++ b/patches/ember-auto-import@2.6.1.patch
@@ -1,0 +1,13 @@
+diff --git a/js/webpack.js b/js/webpack.js
+index 86641517cc55be2349fbed507ec6f93ebd027469..06ba89d05b908b44aa97a7ea6e4aa5a8d0e3101c 100644
+--- a/js/webpack.js
++++ b/js/webpack.js
+@@ -384,7 +384,7 @@ class WebpackBundler extends broccoli_plugin_1.default {
+          */
+         let host = this.opts.rootPackage;
+         let emberSource = host.requestedRange('ember-source');
+-        let emberSourceVersion = semver_1.default.coerce(emberSource);
++        let emberSourceVersion = semver_1.default.valid(emberSource);
+         if (emberSourceVersion && semver_1.default.lt(emberSourceVersion, '3.27.0')) {
+             if (this.opts.earlyBootSet) {
+                 throw new Error('autoImport.earlyBootSet is not supported for ember-source <= 3.27.0');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ overrides:
 
 patchedDependencies:
   ember-auto-import@2.6.1:
-    hash: exndgii63og52gfgzwosi4wmwm
+    hash: ic4j24wybap2f2xedeoakj5qoa
     path: patches/ember-auto-import@2.6.1.patch
   ember-a11y-testing@5.2.0:
     hash: ynlyhbi6rwlli5mc64kgdri6jy
@@ -194,7 +194,7 @@ importers:
       autoprefixer: 10.4.13_postcss@8.4.21
       concurrently: 7.6.0
       cssnano: 5.1.15_postcss@8.4.21
-      ember-auto-import: 2.6.1_webpack@5.75.0
+      ember-auto-import: 2.6.1_ic4j24wybap2f2xedeoakj5qoa_webpack@5.75.0
       ember-cli: 4.10.0
       ember-cli-app-version: 6.0.0_ember-source@4.10.0
       ember-cli-babel: 7.26.11
@@ -704,7 +704,7 @@ importers:
       broccoli-asset-rev: 3.0.0
       concurrently: 7.6.0
       ember-a11y-testing: 5.2.0_ynlyhbi6rwlli5mc64kgdri6jy_xxksirw4yhzqkev2rkehjstyum
-      ember-auto-import: 2.6.1_exndgii63og52gfgzwosi4wmwm_webpack@5.75.0
+      ember-auto-import: 2.6.1_ic4j24wybap2f2xedeoakj5qoa_webpack@5.75.0
       ember-changeset: 4.1.2_webpack@5.75.0
       ember-cli: 4.10.0
       ember-cli-app-version: 5.0.0
@@ -821,7 +821,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/eslint-parser/7.19.1_ydmbqfus77qykiqxhcwsorsqbq:
     resolution: {integrity: sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==}
@@ -1013,7 +1012,6 @@ packages:
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-optimise-call-expression/7.18.6:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
@@ -1115,7 +1113,6 @@ packages:
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/highlight/7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
@@ -1659,6 +1656,7 @@ packages:
         optional: true
     dependencies:
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-block-scoping/7.20.11_@babel+core@7.20.12:
     resolution: {integrity: sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==}
@@ -2329,7 +2327,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/types/7.20.7:
     resolution: {integrity: sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==}
@@ -2976,7 +2973,7 @@ packages:
       '@glint/template': 1.0.0-beta.3
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
     transitivePeerDependencies:
       - supports-color
 
@@ -3187,6 +3184,7 @@ packages:
       babel-plugin-debug-macros: 0.3.4
     transitivePeerDependencies:
       - '@babel/core'
+    dev: true
 
   /@glimmer/vm-babel-plugins/0.84.2_@babel+core@7.20.12:
     resolution: {integrity: sha512-HS2dEbJ3CgXn56wk/5QdudM7rE3vtNMvPIoG7Rrg+GhkGMNxBCIRxOeEF2g520j9rwlA2LAZFpc7MCDMFbTjNA==}
@@ -5335,7 +5333,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12_supports-color@8.1.1
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
@@ -5387,6 +5385,7 @@ packages:
         optional: true
     dependencies:
       semver: 5.7.1
+    dev: true
 
   /babel-plugin-debug-macros/0.3.4_@babel+core@7.20.12:
     resolution: {integrity: sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==}
@@ -7616,7 +7615,6 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
-    dev: true
 
   /decamelize-keys/1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -7909,7 +7907,7 @@ packages:
       axe-core: 4.6.3
       body-parser: 1.20.1
       broccoli-persistent-filter: 3.1.3
-      ember-auto-import: 2.6.1_exndgii63og52gfgzwosi4wmwm_webpack@5.75.0
+      ember-auto-import: 2.6.1_ic4j24wybap2f2xedeoakj5qoa_webpack@5.75.0
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 4.2.1
       ember-cli-version-checker: 5.1.2
@@ -7933,7 +7931,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /ember-auto-import/2.6.1_exndgii63og52gfgzwosi4wmwm_webpack@5.75.0:
+  /ember-auto-import/2.6.1_ic4j24wybap2f2xedeoakj5qoa_webpack@5.75.0:
     resolution: {integrity: sha512-3bCRi/pXp4QslmuCXGlSz9xwR7DF5oDx3zZO5OXKzNZihtkqAM1xvGuRIdQSl46pvbAXOkp8Odl5fOen1i0dRw==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
@@ -7971,44 +7969,6 @@ packages:
       - supports-color
       - webpack
     patched: true
-
-  /ember-auto-import/2.6.1_webpack@5.75.0:
-    resolution: {integrity: sha512-3bCRi/pXp4QslmuCXGlSz9xwR7DF5oDx3zZO5OXKzNZihtkqAM1xvGuRIdQSl46pvbAXOkp8Odl5fOen1i0dRw==}
-    engines: {node: 12.* || 14.* || >= 16}
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-decorators': 7.20.7_@babel+core@7.20.12
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
-      '@embroider/macros': 1.10.0
-      '@embroider/shared-internals': 2.0.0
-      babel-loader: 8.3.0_la66t7xldg4uecmyawueag5wkm
-      babel-plugin-ember-modules-api-polyfill: 3.5.0
-      babel-plugin-htmlbars-inline-precompile: 5.3.1
-      babel-plugin-syntax-dynamic-import: 6.18.0
-      broccoli-debug: 0.6.5
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 4.2.0
-      broccoli-plugin: 4.0.7
-      broccoli-source: 3.0.1
-      css-loader: 5.2.7_webpack@5.75.0
-      debug: 4.3.4
-      fs-extra: 10.1.0
-      fs-tree-diff: 2.0.1
-      handlebars: 4.7.7
-      js-string-escape: 1.0.1
-      lodash: 4.17.21
-      mini-css-extract-plugin: 2.7.2_webpack@5.75.0
-      parse5: 6.0.1
-      resolve: 1.22.1
-      resolve-package-path: 4.0.3
-      semver: 7.3.8
-      style-loader: 2.0.0_webpack@5.75.0
-      typescript-memoize: 1.1.1
-      walk-sync: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
-      - webpack
 
   /ember-browser-services/4.0.4:
     resolution: {integrity: sha512-ZjQPD7wlqMhHIq+uuesW+SWYCN+TsQtyY2Fy7QpluxEQff/j2JHiQAk3K0GUtEwef1gJ8/dRsBqSnaG2/Fxhmg==}
@@ -8053,7 +8013,7 @@ packages:
     resolution: {integrity: sha512-lRT+LOwY+kTMRC/op85L6+FFHDuOkoQvqgexexTiLFECiTNw4vQbOrcAqhfe6n/QJBr5uypZ+bg4W1Ng34dkMg==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
-      ember-auto-import: 2.6.1_webpack@5.75.0
+      ember-auto-import: 2.6.1_ic4j24wybap2f2xedeoakj5qoa_webpack@5.75.0
       ember-cli-babel: 7.26.11
       ember-get-config: 1.1.0
       ember-validators: 4.1.2
@@ -8074,7 +8034,7 @@ packages:
     dependencies:
       '@embroider/macros': 1.10.0
       '@glimmer/tracking': 1.1.2
-      ember-auto-import: 2.6.1_exndgii63og52gfgzwosi4wmwm_webpack@5.75.0
+      ember-auto-import: 2.6.1_ic4j24wybap2f2xedeoakj5qoa_webpack@5.75.0
       ember-cli-babel: 7.26.11
       validated-changeset: 1.3.4
     transitivePeerDependencies:
@@ -8705,7 +8665,7 @@ packages:
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 5.2.1
       ember-cli-version-checker: 5.1.2
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
     transitivePeerDependencies:
       - supports-color
 
@@ -8751,7 +8711,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
     transitivePeerDependencies:
       - supports-color
 
@@ -8781,14 +8741,14 @@ packages:
       ember-source: '>=3.28'
       qunit: ^2.13.0
     dependencies:
-      '@ember/test-helpers': 2.9.3_j4rdeqmk3bfqity5vrrnavkxem
+      '@ember/test-helpers': 2.9.3_dr5a25oqcvtmoy4o567hsz72pe
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
-      ember-auto-import: 2.6.1_exndgii63og52gfgzwosi4wmwm_webpack@5.75.0
+      ember-auto-import: 2.6.1_ic4j24wybap2f2xedeoakj5qoa_webpack@5.75.0
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.0.0
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
       qunit: 2.19.3
       resolve-package-path: 4.0.3
       silent-error: 1.1.1
@@ -8810,7 +8770,7 @@ packages:
     dependencies:
       '@ember/string': 3.0.1
       ember-cli-babel: 7.26.11
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8865,7 +8825,7 @@ packages:
       sinon: ^15.0.1
     dependencies:
       broccoli-funnel: 3.0.8
-      ember-auto-import: 2.6.1_exndgii63og52gfgzwosi4wmwm_webpack@5.75.0
+      ember-auto-import: 2.6.1_ic4j24wybap2f2xedeoakj5qoa_webpack@5.75.0
       ember-cli-babel: 7.26.11
       ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
       sinon: 15.0.1
@@ -8903,7 +8863,7 @@ packages:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-auto-import: 2.6.1_webpack@5.75.0
+      ember-auto-import: 2.6.1_ic4j24wybap2f2xedeoakj5qoa_webpack@5.75.0
       ember-cli-babel: 7.26.11
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
@@ -8941,7 +8901,7 @@ packages:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-auto-import: 2.6.1_exndgii63og52gfgzwosi4wmwm_webpack@5.75.0
+      ember-auto-import: 2.6.1_ic4j24wybap2f2xedeoakj5qoa_webpack@5.75.0
       ember-cli-babel: 7.26.11
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
@@ -8959,6 +8919,7 @@ packages:
       - '@babel/core'
       - supports-color
       - webpack
+    dev: true
 
   /ember-template-imports/3.4.1:
     resolution: {integrity: sha512-KXnBFTAVxCfXnSCUgd/iuic9ajWbmFkRUBEeorJAMqxvougsPoK22s5ygE9O3GnzYdPpMwn+8v+/NAGy8HRBGA==}
@@ -17292,7 +17253,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-changeset: 4.1.2_webpack@5.75.0
       ember-headless-form: file:packages/ember-headless-form_5vzw4sbxxshw4bfzsmeoaa5v3q
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
       validated-changeset: 1.3.4
     transitivePeerDependencies:
       - supports-color
@@ -17311,11 +17272,11 @@ packages:
       '@ember/test-waiters': 3.0.2
       '@embroider/addon-shim': 1.8.4
       '@embroider/util': 1.10.0_j4rdeqmk3bfqity5vrrnavkxem
-      '@glimmer/component': 1.1.2
+      '@glimmer/component': 1.1.2_@babel+core@7.20.12
       '@glimmer/tracking': 1.1.2
       ember-async-data: 0.7.0
       ember-modifier: 4.1.0_ember-source@4.10.0
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
       tracked-built-ins: 3.1.0
     transitivePeerDependencies:
       - '@glint/template'
@@ -17334,7 +17295,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-functions-as-helper-polyfill: 2.1.1_ember-source@4.10.0
       ember-headless-form: file:packages/ember-headless-form_5vzw4sbxxshw4bfzsmeoaa5v3q
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
       yup: 1.0.0
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,7 +361,6 @@ importers:
       '@babel/plugin-syntax-decorators': ^7.17.0
       '@babel/preset-typescript': ^7.18.6
       '@babel/runtime': ^7.20.7
-      '@ember/test-waiters': ^3.0.2
       '@embroider/addon-dev': ^3.0.0
       '@embroider/addon-shim': ^1.0.0
       '@embroider/util': ^1.10.0
@@ -393,6 +392,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.30.5
       '@typescript-eslint/parser': ^5.30.5
       concurrently: ^7.2.1
+      ember-async-data: ^0.7.0
       ember-modifier: ^4.1.0
       ember-source: ^4.4.0
       ember-template-lint: ^4.0.0
@@ -410,9 +410,9 @@ importers:
       webpack: ^5.75.0
     dependencies:
       '@babel/runtime': 7.20.7
-      '@ember/test-waiters': 3.0.2
       '@embroider/addon-shim': 1.8.4
       '@embroider/util': 1.10.0_j4rdeqmk3bfqity5vrrnavkxem
+      ember-async-data: 0.7.0
       ember-modifier: 4.1.0_ember-source@4.10.0
       tracked-built-ins: 3.1.0
     devDependencies:
@@ -433,16 +433,16 @@ importers:
       '@types/ember__application': 4.0.5_@babel+core@7.20.12
       '@types/ember__array': 4.0.3_@babel+core@7.20.12
       '@types/ember__component': 4.0.12_@babel+core@7.20.12
-      '@types/ember__controller': 4.0.4
-      '@types/ember__debug': 4.0.3
-      '@types/ember__engine': 4.0.4
+      '@types/ember__controller': 4.0.4_@babel+core@7.20.12
+      '@types/ember__debug': 4.0.3_@babel+core@7.20.12
+      '@types/ember__engine': 4.0.4_@babel+core@7.20.12
       '@types/ember__error': 4.0.2
       '@types/ember__modifier': 4.0.3_@babel+core@7.20.12
-      '@types/ember__object': 4.0.5
+      '@types/ember__object': 4.0.5_@babel+core@7.20.12
       '@types/ember__polyfills': 4.0.1
       '@types/ember__routing': 4.0.12_@babel+core@7.20.12
       '@types/ember__runloop': 4.0.2_@babel+core@7.20.12
-      '@types/ember__service': 4.0.2
+      '@types/ember__service': 4.0.2_@babel+core@7.20.12
       '@types/ember__string': 3.16.3
       '@types/ember__template': 4.0.1
       '@types/ember__test': 4.0.1_@babel+core@7.20.12
@@ -3280,8 +3280,8 @@ packages:
       '@glint/template': 1.0.0-beta.3
       '@types/ember__array': 4.0.3_@babel+core@7.20.12
       '@types/ember__component': 4.0.12_@babel+core@7.20.12
-      '@types/ember__controller': 4.0.4
-      '@types/ember__object': 4.0.5
+      '@types/ember__controller': 4.0.4_@babel+core@7.20.12
+      '@types/ember__object': 4.0.5_@babel+core@7.20.12
       '@types/ember__routing': 4.0.12_@babel+core@7.20.12
       ember-modifier: 4.1.0_ember-source@4.10.0
     dev: true
@@ -7918,6 +7918,15 @@ packages:
       - webpack
     dev: true
     patched: true
+
+  /ember-async-data/0.7.0:
+    resolution: {integrity: sha512-hiHSSMXYGd4eBM+w1EYCHiIkfnTpup/mxEUeEGVMmaAAzVMjb+ACieEPx2xoZ5Wi5baswYMKIIyoKDWT69645Q==}
+    engines: {node: 14.* || 16.* || >= 18}
+    dependencies:
+      '@ember/test-waiters': 3.0.2
+      '@embroider/addon-shim': 1.8.4
+    transitivePeerDependencies:
+      - supports-color
 
   /ember-auto-import/2.6.1_webpack@5.75.0:
     resolution: {integrity: sha512-3bCRi/pXp4QslmuCXGlSz9xwR7DF5oDx3zZO5OXKzNZihtkqAM1xvGuRIdQSl46pvbAXOkp8Odl5fOen1i0dRw==}
@@ -17261,6 +17270,7 @@ packages:
       '@embroider/util': 1.10.0_j4rdeqmk3bfqity5vrrnavkxem
       '@glimmer/component': 1.1.2_@babel+core@7.20.12
       '@glimmer/tracking': 1.1.2
+      ember-async-data: 0.7.0
       ember-modifier: 4.1.0_ember-source@4.10.0
       ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
       tracked-built-ins: 3.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ overrides:
   '@types/eslint': ^7.0.0
 
 patchedDependencies:
+  ember-auto-import@2.6.1:
+    hash: exndgii63og52gfgzwosi4wmwm
+    path: patches/ember-auto-import@2.6.1.patch
   ember-a11y-testing@5.2.0:
     hash: ynlyhbi6rwlli5mc64kgdri6jy
     path: patches/ember-a11y-testing@5.2.0.patch
@@ -701,7 +704,7 @@ importers:
       broccoli-asset-rev: 3.0.0
       concurrently: 7.6.0
       ember-a11y-testing: 5.2.0_ynlyhbi6rwlli5mc64kgdri6jy_xxksirw4yhzqkev2rkehjstyum
-      ember-auto-import: 2.6.1_webpack@5.75.0
+      ember-auto-import: 2.6.1_exndgii63og52gfgzwosi4wmwm_webpack@5.75.0
       ember-changeset: 4.1.2_webpack@5.75.0
       ember-cli: 4.10.0
       ember-cli-app-version: 5.0.0
@@ -818,6 +821,7 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/eslint-parser/7.19.1_ydmbqfus77qykiqxhcwsorsqbq:
     resolution: {integrity: sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==}
@@ -1009,6 +1013,7 @@ packages:
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helper-optimise-call-expression/7.18.6:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
@@ -1110,6 +1115,7 @@ packages:
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/highlight/7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
@@ -1653,7 +1659,6 @@ packages:
         optional: true
     dependencies:
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-block-scoping/7.20.11_@babel+core@7.20.12:
     resolution: {integrity: sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==}
@@ -2324,6 +2329,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/types/7.20.7:
     resolution: {integrity: sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==}
@@ -2970,7 +2976,7 @@ packages:
       '@glint/template': 1.0.0-beta.3
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
     transitivePeerDependencies:
       - supports-color
 
@@ -3181,7 +3187,6 @@ packages:
       babel-plugin-debug-macros: 0.3.4
     transitivePeerDependencies:
       - '@babel/core'
-    dev: true
 
   /@glimmer/vm-babel-plugins/0.84.2_@babel+core@7.20.12:
     resolution: {integrity: sha512-HS2dEbJ3CgXn56wk/5QdudM7rE3vtNMvPIoG7Rrg+GhkGMNxBCIRxOeEF2g520j9rwlA2LAZFpc7MCDMFbTjNA==}
@@ -5330,7 +5335,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.20.12_supports-color@8.1.1
+      '@babel/core': 7.20.12
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
@@ -5382,7 +5387,6 @@ packages:
         optional: true
     dependencies:
       semver: 5.7.1
-    dev: true
 
   /babel-plugin-debug-macros/0.3.4_@babel+core@7.20.12:
     resolution: {integrity: sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==}
@@ -7612,6 +7616,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
+    dev: true
 
   /decamelize-keys/1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -7904,7 +7909,7 @@ packages:
       axe-core: 4.6.3
       body-parser: 1.20.1
       broccoli-persistent-filter: 3.1.3
-      ember-auto-import: 2.6.1_webpack@5.75.0
+      ember-auto-import: 2.6.1_exndgii63og52gfgzwosi4wmwm_webpack@5.75.0
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 4.2.1
       ember-cli-version-checker: 5.1.2
@@ -7927,6 +7932,45 @@ packages:
       '@embroider/addon-shim': 1.8.4
     transitivePeerDependencies:
       - supports-color
+
+  /ember-auto-import/2.6.1_exndgii63og52gfgzwosi4wmwm_webpack@5.75.0:
+    resolution: {integrity: sha512-3bCRi/pXp4QslmuCXGlSz9xwR7DF5oDx3zZO5OXKzNZihtkqAM1xvGuRIdQSl46pvbAXOkp8Odl5fOen1i0dRw==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      '@babel/core': 7.20.12
+      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.20.12
+      '@babel/plugin-proposal-decorators': 7.20.7_@babel+core@7.20.12
+      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
+      '@embroider/macros': 1.10.0
+      '@embroider/shared-internals': 2.0.0
+      babel-loader: 8.3.0_la66t7xldg4uecmyawueag5wkm
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      babel-plugin-htmlbars-inline-precompile: 5.3.1
+      babel-plugin-syntax-dynamic-import: 6.18.0
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      css-loader: 5.2.7_webpack@5.75.0
+      debug: 4.3.4
+      fs-extra: 10.1.0
+      fs-tree-diff: 2.0.1
+      handlebars: 4.7.7
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.7.2_webpack@5.75.0
+      parse5: 6.0.1
+      resolve: 1.22.1
+      resolve-package-path: 4.0.3
+      semver: 7.3.8
+      style-loader: 2.0.0_webpack@5.75.0
+      typescript-memoize: 1.1.1
+      walk-sync: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - webpack
+    patched: true
 
   /ember-auto-import/2.6.1_webpack@5.75.0:
     resolution: {integrity: sha512-3bCRi/pXp4QslmuCXGlSz9xwR7DF5oDx3zZO5OXKzNZihtkqAM1xvGuRIdQSl46pvbAXOkp8Odl5fOen1i0dRw==}
@@ -8030,7 +8074,7 @@ packages:
     dependencies:
       '@embroider/macros': 1.10.0
       '@glimmer/tracking': 1.1.2
-      ember-auto-import: 2.6.1_webpack@5.75.0
+      ember-auto-import: 2.6.1_exndgii63og52gfgzwosi4wmwm_webpack@5.75.0
       ember-cli-babel: 7.26.11
       validated-changeset: 1.3.4
     transitivePeerDependencies:
@@ -8661,7 +8705,7 @@ packages:
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 5.2.1
       ember-cli-version-checker: 5.1.2
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
     transitivePeerDependencies:
       - supports-color
 
@@ -8707,7 +8751,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
     transitivePeerDependencies:
       - supports-color
 
@@ -8737,14 +8781,14 @@ packages:
       ember-source: '>=3.28'
       qunit: ^2.13.0
     dependencies:
-      '@ember/test-helpers': 2.9.3_dr5a25oqcvtmoy4o567hsz72pe
+      '@ember/test-helpers': 2.9.3_j4rdeqmk3bfqity5vrrnavkxem
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
-      ember-auto-import: 2.6.1_webpack@5.75.0
+      ember-auto-import: 2.6.1_exndgii63og52gfgzwosi4wmwm_webpack@5.75.0
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.0.0
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
       qunit: 2.19.3
       resolve-package-path: 4.0.3
       silent-error: 1.1.1
@@ -8766,7 +8810,7 @@ packages:
     dependencies:
       '@ember/string': 3.0.1
       ember-cli-babel: 7.26.11
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8821,7 +8865,7 @@ packages:
       sinon: ^15.0.1
     dependencies:
       broccoli-funnel: 3.0.8
-      ember-auto-import: 2.6.1_webpack@5.75.0
+      ember-auto-import: 2.6.1_exndgii63og52gfgzwosi4wmwm_webpack@5.75.0
       ember-cli-babel: 7.26.11
       ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
       sinon: 15.0.1
@@ -8897,7 +8941,7 @@ packages:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-auto-import: 2.6.1_webpack@5.75.0
+      ember-auto-import: 2.6.1_exndgii63og52gfgzwosi4wmwm_webpack@5.75.0
       ember-cli-babel: 7.26.11
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
@@ -8915,7 +8959,6 @@ packages:
       - '@babel/core'
       - supports-color
       - webpack
-    dev: true
 
   /ember-template-imports/3.4.1:
     resolution: {integrity: sha512-KXnBFTAVxCfXnSCUgd/iuic9ajWbmFkRUBEeorJAMqxvougsPoK22s5ygE9O3GnzYdPpMwn+8v+/NAGy8HRBGA==}
@@ -17249,7 +17292,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-changeset: 4.1.2_webpack@5.75.0
       ember-headless-form: file:packages/ember-headless-form_5vzw4sbxxshw4bfzsmeoaa5v3q
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
       validated-changeset: 1.3.4
     transitivePeerDependencies:
       - supports-color
@@ -17268,11 +17311,11 @@ packages:
       '@ember/test-waiters': 3.0.2
       '@embroider/addon-shim': 1.8.4
       '@embroider/util': 1.10.0_j4rdeqmk3bfqity5vrrnavkxem
-      '@glimmer/component': 1.1.2_@babel+core@7.20.12
+      '@glimmer/component': 1.1.2
       '@glimmer/tracking': 1.1.2
       ember-async-data: 0.7.0
       ember-modifier: 4.1.0_ember-source@4.10.0
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
       tracked-built-ins: 3.1.0
     transitivePeerDependencies:
       - '@glint/template'
@@ -17291,7 +17334,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-functions-as-helper-polyfill: 2.1.1_ember-source@4.10.0
       ember-headless-form: file:packages/ember-headless-form_5vzw4sbxxshw4bfzsmeoaa5v3q
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
       yup: 1.0.0
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -616,6 +616,7 @@ importers:
       broccoli-asset-rev: ^3.0.0
       concurrently: ^7.6.0
       ember-a11y-testing: ^5.2.0
+      ember-async-data: ^0.7.0
       ember-auto-import: ^2.5.0
       ember-changeset: ^4.1.2
       ember-cli: ~4.10.0-beta.0
@@ -704,6 +705,7 @@ importers:
       broccoli-asset-rev: 3.0.0
       concurrently: 7.6.0
       ember-a11y-testing: 5.2.0_ynlyhbi6rwlli5mc64kgdri6jy_xxksirw4yhzqkev2rkehjstyum
+      ember-async-data: 0.7.0
       ember-auto-import: 2.6.1_ic4j24wybap2f2xedeoakj5qoa_webpack@5.75.0
       ember-changeset: 4.1.2_webpack@5.75.0
       ember-cli: 4.10.0
@@ -821,6 +823,7 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/eslint-parser/7.19.1_ydmbqfus77qykiqxhcwsorsqbq:
     resolution: {integrity: sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==}
@@ -1012,6 +1015,7 @@ packages:
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helper-optimise-call-expression/7.18.6:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
@@ -1113,6 +1117,7 @@ packages:
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/highlight/7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
@@ -1656,7 +1661,6 @@ packages:
         optional: true
     dependencies:
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-block-scoping/7.20.11_@babel+core@7.20.12:
     resolution: {integrity: sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==}
@@ -2327,6 +2331,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/types/7.20.7:
     resolution: {integrity: sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==}
@@ -2973,7 +2978,7 @@ packages:
       '@glint/template': 1.0.0-beta.3
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
     transitivePeerDependencies:
       - supports-color
 
@@ -3184,7 +3189,6 @@ packages:
       babel-plugin-debug-macros: 0.3.4
     transitivePeerDependencies:
       - '@babel/core'
-    dev: true
 
   /@glimmer/vm-babel-plugins/0.84.2_@babel+core@7.20.12:
     resolution: {integrity: sha512-HS2dEbJ3CgXn56wk/5QdudM7rE3vtNMvPIoG7Rrg+GhkGMNxBCIRxOeEF2g520j9rwlA2LAZFpc7MCDMFbTjNA==}
@@ -5333,7 +5337,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.20.12_supports-color@8.1.1
+      '@babel/core': 7.20.12
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
@@ -5385,7 +5389,6 @@ packages:
         optional: true
     dependencies:
       semver: 5.7.1
-    dev: true
 
   /babel-plugin-debug-macros/0.3.4_@babel+core@7.20.12:
     resolution: {integrity: sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==}
@@ -7615,6 +7618,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
+    dev: true
 
   /decamelize-keys/1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -8665,7 +8669,7 @@ packages:
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 5.2.1
       ember-cli-version-checker: 5.1.2
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
     transitivePeerDependencies:
       - supports-color
 
@@ -8711,7 +8715,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
     transitivePeerDependencies:
       - supports-color
 
@@ -8741,14 +8745,14 @@ packages:
       ember-source: '>=3.28'
       qunit: ^2.13.0
     dependencies:
-      '@ember/test-helpers': 2.9.3_dr5a25oqcvtmoy4o567hsz72pe
+      '@ember/test-helpers': 2.9.3_j4rdeqmk3bfqity5vrrnavkxem
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
       ember-auto-import: 2.6.1_ic4j24wybap2f2xedeoakj5qoa_webpack@5.75.0
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.0.0
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
       qunit: 2.19.3
       resolve-package-path: 4.0.3
       silent-error: 1.1.1
@@ -8770,7 +8774,7 @@ packages:
     dependencies:
       '@ember/string': 3.0.1
       ember-cli-babel: 7.26.11
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8919,7 +8923,6 @@ packages:
       - '@babel/core'
       - supports-color
       - webpack
-    dev: true
 
   /ember-template-imports/3.4.1:
     resolution: {integrity: sha512-KXnBFTAVxCfXnSCUgd/iuic9ajWbmFkRUBEeorJAMqxvougsPoK22s5ygE9O3GnzYdPpMwn+8v+/NAGy8HRBGA==}
@@ -17253,7 +17256,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-changeset: 4.1.2_webpack@5.75.0
       ember-headless-form: file:packages/ember-headless-form_5vzw4sbxxshw4bfzsmeoaa5v3q
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
       validated-changeset: 1.3.4
     transitivePeerDependencies:
       - supports-color
@@ -17272,11 +17275,11 @@ packages:
       '@ember/test-waiters': 3.0.2
       '@embroider/addon-shim': 1.8.4
       '@embroider/util': 1.10.0_j4rdeqmk3bfqity5vrrnavkxem
-      '@glimmer/component': 1.1.2_@babel+core@7.20.12
+      '@glimmer/component': 1.1.2
       '@glimmer/tracking': 1.1.2
       ember-async-data: 0.7.0
       ember-modifier: 4.1.0_ember-source@4.10.0
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
       tracked-built-ins: 3.1.0
     transitivePeerDependencies:
       - '@glint/template'
@@ -17295,7 +17298,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-functions-as-helper-polyfill: 2.1.1_ember-source@4.10.0
       ember-headless-form: file:packages/ember-headless-form_5vzw4sbxxshw4bfzsmeoaa5v3q
-      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
+      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
       yup: 1.0.0
     transitivePeerDependencies:
       - supports-color

--- a/test-app/ember-cli-build.js
+++ b/test-app/ember-cli-build.js
@@ -9,6 +9,8 @@ module.exports = function (defaults) {
         'ember-headless-form',
         '@ember-headless-form/changeset',
       ],
+      // See https://github.com/ef4/ember-auto-import/issues/564#issuecomment-1448820349
+      earlyBootSet: () => ['@glimmer/tracking'],
     },
   });
 

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -74,6 +74,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^7.6.0",
     "ember-a11y-testing": "^5.2.0",
+    "ember-async-data": "^0.7.0",
     "ember-auto-import": "^2.5.0",
     "ember-changeset": "^4.1.2",
     "ember-cli": "~4.10.0-beta.0",
@@ -110,11 +111,11 @@
     "qunit": "^2.19.3",
     "qunit-dom": "^2.0.0",
     "sinon": "^15.0.1",
+    "sync-pnpm": "workspace:*",
     "typescript": "^4.9.4",
     "validated-changeset": "^1.3.4",
     "webpack": "^5.75.0",
-    "yup": "^1.0.0",
-    "sync-pnpm": "workspace:*"
+    "yup": "^1.0.0"
   },
   "dependenciesMeta": {
     "ember-headless-form": {

--- a/test-app/tests/integration/components/headless-form-async-test.gts
+++ b/test-app/tests/integration/components/headless-form-async-test.gts
@@ -1,0 +1,175 @@
+/* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
+/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
+
+import { tracked } from '@glimmer/tracking';
+import {
+  blur,
+  click,
+  fillIn,
+  render,
+  rerender,
+  waitFor,
+} from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { HeadlessForm } from 'ember-headless-form';
+import sinon from 'sinon';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+import type { RenderingTestContext } from '@ember/test-helpers';
+import type {
+  FormValidateCallback,
+  FieldValidateCallback,
+  ErrorRecord,
+  ValidationError,
+} from 'ember-headless-form';
+
+import { input } from '../../helpers/dom';
+
+module('Integration Component HeadlessForm > Async state', function (hooks) {
+  setupRenderingTest(hooks);
+
+  interface TestFormData {
+    firstName?: string;
+    lastName?: string;
+  }
+
+  const validateFieldCallbackSync: FieldValidateCallback<TestFormData> = (
+    value,
+    field
+  ) => {
+    const errors = [];
+    if (value == undefined) {
+      errors.push({
+        type: 'required',
+        value,
+        message: `${field} is required!`,
+      });
+    } else {
+      if (value.charAt(0).toUpperCase() !== value.charAt(0)) {
+        errors.push({
+          type: 'uppercase',
+          value,
+          message: `${field} must be upper case!`,
+        });
+      }
+
+      if (value.toLowerCase() === 'foo') {
+        errors.push({
+          type: 'notFoo',
+          value,
+          message: `Foo is an invalid ${field}!`,
+        });
+      }
+    }
+
+    return errors.length > 0 ? errors : undefined;
+  };
+
+  const validateFieldCallbackAsync: FieldValidateCallback<
+    TestFormData
+  > = async (value, field, data) => {
+    // intentionally adding a delay here, to make the validation behave truly async and assert that we are correctly waiting for it in tests
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    return validateFieldCallbackSync(value, field, data);
+  };
+
+  const stringify = (data: unknown) => JSON.stringify(data);
+
+  module('validation', function () {
+    test('validation state is yielded - valid', async function (assert) {
+      const data: TestFormData = { firstName: 'Tony', lastName: 'Ward' };
+
+      await render(<template>
+        <HeadlessForm @data={{data}} as |form|>
+          <form.Field
+            @name="firstName"
+            @validate={{validateFieldCallbackAsync}}
+            as |field|
+          >
+            <field.Label>First Name</field.Label>
+            <field.Input data-test-first-name />
+          </form.Field>
+          <button type="submit" data-test-submit>Submit</button>
+          {{#if form.validationState}}
+            <div data-test-validation-state>{{form.validationState.state}}</div>
+            {{#if form.validationState.isResolved}}
+              <div data-test-validation-value>
+                {{stringify form.validationState.value}}
+              </div>
+            {{/if}}
+          {{/if}}
+        </HeadlessForm>
+      </template>);
+
+      assert
+        .dom('[data-test-validation-state]')
+        .doesNotExist('form.validation is not present until first validation');
+
+      const promise = click('[data-test-submit]');
+      await waitFor('[data-test-validation-state]');
+
+      assert
+        .dom('[data-test-validation-state]')
+        .hasText('PENDING', 'form.validation is pending');
+
+      await promise;
+
+      assert
+        .dom('[data-test-validation-state]')
+        .hasText('RESOLVED', 'form.validation has resolved');
+      assert
+        .dom('[data-test-validation-value]')
+        .hasText('{}', 'validationState.value has no errors');
+    });
+
+    test('validation state is yielded - invalid', async function (assert) {
+      const data: TestFormData = { firstName: 'Foo', lastName: 'Smith' };
+
+      await render(<template>
+        <HeadlessForm @data={{data}} as |form|>
+          <form.Field
+            @name="firstName"
+            @validate={{validateFieldCallbackAsync}}
+            as |field|
+          >
+            <field.Label>First Name</field.Label>
+            <field.Input data-test-first-name />
+          </form.Field>
+          <button type="submit" data-test-submit>Submit</button>
+          {{#if form.validationState}}
+            <div data-test-validation-state>{{form.validationState.state}}</div>
+            {{#if form.validationState.isResolved}}
+              <div data-test-validation-value>
+                {{stringify form.validationState.value}}
+              </div>
+            {{/if}}
+          {{/if}}
+        </HeadlessForm>
+      </template>);
+
+      assert
+        .dom('[data-test-validation-state]')
+        .doesNotExist('form.validation is not present until first validation');
+
+      const promise = click('[data-test-submit]');
+      await waitFor('[data-test-validation-state]');
+
+      assert
+        .dom('[data-test-validation-state]')
+        .hasText('PENDING', 'form.validation is pending');
+
+      await promise;
+
+      assert
+        .dom('[data-test-validation-state]')
+        .hasText('RESOLVED', 'form.validation has resolved');
+      assert
+        .dom('[data-test-validation-value]')
+        .hasText(
+          '{"firstName":[{"type":"notFoo","value":"Foo","message":"Foo is an invalid firstName!"}]}',
+          'validationState.value has ErrorRecord'
+        );
+    });
+  });
+});


### PR DESCRIPTION
Validation and submission can both be async. This yields the async state (pending/resolved) back to the template, so you can react to it, like disabling a submit button or changing labels.

This uses https://github.com/tracked-tools/ember-async-data, and exposes their interface as our own public API, i.e. users will directly be able to use e.g.`.isPending`. This means we are not hiding it as an implementation detail, so we also cannot remove it without breaking things. But I think this is acceptable, as we also don't want to reinvent things, especially not its very good [TypeScript support](https://github.com/tracked-tools/ember-async-data#with-typescript). Therefore the tests also don't cover all the details of _their_ API, as they already have good test coverage.

To Do:

- [x]  add docs after #58 is merged