### PR TITLE
Fix sync-pnpm when already synced previously

### DIFF
--- a/internal/sync-pnpm/index.js
+++ b/internal/sync-pnpm/index.js
@@ -3,11 +3,13 @@ import { createRequire } from 'node:module';
 
 import { getPackages } from '@manypkg/get-packages';
 import { findRoot } from '@manypkg/find-root';
-import { readJson, pathExists } from 'fs-extra/esm';
+import { readJson, pathExists, remove } from 'fs-extra/esm';
 import { hardLinkDir } from '@pnpm/fs.hard-link-dir';
 import resolvePackagePath from 'resolve-package-path';
+import Debug from 'debug';
 
 const require = createRequire(import.meta.url);
+const debug = Debug('sync-pnpm');
 
 const syncDir = './dist';
 
@@ -35,6 +37,12 @@ export default async function syncPnpm(dir = process.cwd()) {
     const syncTo = join(resolvedPackagePath, syncDir);
 
     if (await pathExists(syncFrom)) {
+      if (await pathExists(syncTo)) {
+        await remove(syncTo);
+        debug(`removed ${syncTo} before syncing`);
+      }
+
+      debug(`syncing from ${syncFrom} to ${syncTo}`);
       await hardLinkDir(syncFrom, [syncTo]);
     }
   }

--- a/internal/sync-pnpm/package.json
+++ b/internal/sync-pnpm/package.json
@@ -13,6 +13,7 @@
     "@manypkg/find-root": "^2.1.0",
     "@manypkg/get-packages": "^2.1.0",
     "@pnpm/fs.hard-link-dir": "^1.0.3",
+    "debug": "^4.3.4",
     "fs-extra": "^11.1.0",
     "resolve-package-path": "^4.0.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,12 +223,14 @@ importers:
       '@manypkg/find-root': ^2.1.0
       '@manypkg/get-packages': ^2.1.0
       '@pnpm/fs.hard-link-dir': ^1.0.3
+      debug: ^4.3.4
       fs-extra: ^11.1.0
       resolve-package-path: ^4.0.3
     dependencies:
       '@manypkg/find-root': 2.1.0
       '@manypkg/get-packages': 2.1.0
       '@pnpm/fs.hard-link-dir': 1.0.3
+      debug: 4.3.4
       fs-extra: 11.1.0
       resolve-package-path: 4.0.3
 


### PR DESCRIPTION
The sync script would skip syncing the `dist` folder when it already exists. This is not good when running things locally, like when you run the test-app, and build the addon in watch mode, you would still need to run the sync script after changes in the addon manually. But without this fix here, it would not update the `dist` output with the addon changes.

Currently my development workflow with this is:
* `pnpm start` (runs test-app)
* in another terminal:
  * `cd <addon-dir>`
  * `pnpm start` (rollup in watch mode)
 * in yet another terminal:
   * `cd test-app`
   * on every change of the addon run manually: `pnpm _syncPnpm`

Far from good, but at least works...