### PR TITLE
Yield `rawErrors` for custom error rendering

### DIFF
--- a/.changeset/heavy-experts-wonder.md
+++ b/.changeset/heavy-experts-wonder.md
@@ -1,0 +1,7 @@
+---
+'ember-headless-form': patch
+---
+
+Yield `rawErrors` for custom error rendering
+
+Both the form and each field yield a `rawErrors` property that gives access to the raw validation error objects for custom error rendering.

--- a/docs/validation/index.md
+++ b/docs/validation/index.md
@@ -70,3 +70,8 @@ For rendering other markup based on the current validation state, both the form 
   <button type='submit'>Submit</button>
 </HeadlessForm>
 ```
+
+If you prefer to not use the yielded `<field.Errors>` component for error rendering, you can use the raw `ValidationError` objects instead to render them on your own. They are yielded as `rawErrors`
+
+- from the form, as an `ErrorRecord` for all fields
+- from each field as an array of `ValidationError`s

--- a/packages/ember-headless-form/src/-private/components/field.hbs
+++ b/packages/ember-headless-form/src/-private/components/field.hbs
@@ -65,6 +65,7 @@
         )
       )
       isInvalid=this.hasErrors
+      rawErrors=this.errors
       triggerValidation=triggerValidation
       captureEvents=(modifier
         this.CaptureEventsModifier

--- a/packages/ember-headless-form/src/-private/components/field.ts
+++ b/packages/ember-headless-form/src/-private/components/field.ts
@@ -179,6 +179,11 @@ export interface HeadlessFormFieldComponentSignature<
         isInvalid: boolean;
 
         /**
+         * An array of raw ValidationError objects, for custom rendering of error output
+         */
+        rawErrors?: ValidationError<DATA[KEY]>[];
+
+        /**
          * When calling this action, validation will be triggered.
          *
          * Can be used for custom controls that don't emit the `@validateOn` events that would normally trigger a dynamic validation.

--- a/packages/ember-headless-form/src/components/headless-form.hbs
+++ b/packages/ember-headless-form/src/components/headless-form.hbs
@@ -28,6 +28,7 @@
       validationState=this.validationState
       submissionState=this.submissionState
       isInvalid=this.hasValidationErrors
+      rawErrors=this.visibleErrors
     )
   }}
 </form>

--- a/packages/ember-headless-form/src/components/headless-form.ts
+++ b/packages/ember-headless-form/src/components/headless-form.ts
@@ -113,6 +113,11 @@ export interface HeadlessFormComponentSignature<
          * Will be true if at least one form field is invalid.
          */
         isInvalid: boolean;
+
+        /**
+         * An ErrorRecord, for custom rendering of error output
+         */
+        rawErrors?: ErrorRecord<DATA>;
       }
     ];
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,8 +137,8 @@ importers:
       ember-changeset: 4.1.2_webpack@5.75.0
       ember-changeset-validations: 4.1.1_webpack@5.75.0
       ember-headless-form: file:packages/ember-headless-form_5vzw4sbxxshw4bfzsmeoaa5v3q
-      ember-headless-form-changeset: file:packages/changeset_nvoyrptyri5bht4zowzxn7dh4u
-      ember-headless-form-yup: file:packages/yup_zbfsva7qssna2hnv7fbg4kxb2u
+      ember-headless-form-changeset: file:packages/changeset_szgngu72sv6keipnf6anz4jfha
+      ember-headless-form-yup: file:packages/yup_npvmoipinnb7efewnloevbpgra
       ember-modifier: 4.1.0_ember-source@4.10.0
       ember-resources: 5.6.2_3mo5bya6mlbe5tgl2ggppknsju
       highlight.js: 11.7.0
@@ -290,7 +290,7 @@ importers:
       '@typescript-eslint/parser': ^5.30.5
       concurrently: ^7.2.1
       ember-changeset: ^4.0.0
-      ember-headless-form: ^0.0.0
+      ember-headless-form: ^1.0.0-beta.0
       ember-source: ~4.10.0
       ember-template-lint: ^4.0.0
       eslint: ^7.32.0
@@ -502,7 +502,7 @@ importers:
       '@typescript-eslint/parser': ^5.30.5
       concurrently: ^7.2.1
       ember-functions-as-helper-polyfill: ^2.1.1
-      ember-headless-form: ^0.0.0
+      ember-headless-form: ^1.0.0-beta.0
       ember-source: ~4.10.0
       ember-template-lint: ^4.0.0
       eslint: ^7.32.0
@@ -718,8 +718,8 @@ importers:
       ember-disable-prototype-extensions: 1.1.3
       ember-fetch: 8.1.2
       ember-headless-form: file:packages/ember-headless-form_5vzw4sbxxshw4bfzsmeoaa5v3q
-      ember-headless-form-changeset: file:packages/changeset_nvoyrptyri5bht4zowzxn7dh4u
-      ember-headless-form-yup: file:packages/yup_zbfsva7qssna2hnv7fbg4kxb2u
+      ember-headless-form-changeset: file:packages/changeset_szgngu72sv6keipnf6anz4jfha
+      ember-headless-form-yup: file:packages/yup_npvmoipinnb7efewnloevbpgra
       ember-load-initializers: 2.1.2
       ember-page-title: 7.0.0
       ember-qunit: 6.2.0_woikvfee7zmxth2th3lg3fsk5i
@@ -823,7 +823,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/eslint-parser/7.19.1_ydmbqfus77qykiqxhcwsorsqbq:
     resolution: {integrity: sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==}
@@ -1015,7 +1014,6 @@ packages:
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-optimise-call-expression/7.18.6:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
@@ -1117,7 +1115,6 @@ packages:
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/highlight/7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
@@ -1661,6 +1658,7 @@ packages:
         optional: true
     dependencies:
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-block-scoping/7.20.11_@babel+core@7.20.12:
     resolution: {integrity: sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==}
@@ -2331,7 +2329,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/types/7.20.7:
     resolution: {integrity: sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==}
@@ -2978,7 +2975,7 @@ packages:
       '@glint/template': 1.0.0-beta.3
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
     transitivePeerDependencies:
       - supports-color
 
@@ -3189,6 +3186,7 @@ packages:
       babel-plugin-debug-macros: 0.3.4
     transitivePeerDependencies:
       - '@babel/core'
+    dev: true
 
   /@glimmer/vm-babel-plugins/0.84.2_@babel+core@7.20.12:
     resolution: {integrity: sha512-HS2dEbJ3CgXn56wk/5QdudM7rE3vtNMvPIoG7Rrg+GhkGMNxBCIRxOeEF2g520j9rwlA2LAZFpc7MCDMFbTjNA==}
@@ -5337,7 +5335,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12_supports-color@8.1.1
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
@@ -5389,6 +5387,7 @@ packages:
         optional: true
     dependencies:
       semver: 5.7.1
+    dev: true
 
   /babel-plugin-debug-macros/0.3.4_@babel+core@7.20.12:
     resolution: {integrity: sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==}
@@ -7618,7 +7617,6 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
-    dev: true
 
   /decamelize-keys/1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -8669,7 +8667,7 @@ packages:
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 5.2.1
       ember-cli-version-checker: 5.1.2
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
     transitivePeerDependencies:
       - supports-color
 
@@ -8715,7 +8713,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
     transitivePeerDependencies:
       - supports-color
 
@@ -8745,14 +8743,14 @@ packages:
       ember-source: '>=3.28'
       qunit: ^2.13.0
     dependencies:
-      '@ember/test-helpers': 2.9.3_j4rdeqmk3bfqity5vrrnavkxem
+      '@ember/test-helpers': 2.9.3_dr5a25oqcvtmoy4o567hsz72pe
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
       ember-auto-import: 2.6.1_ic4j24wybap2f2xedeoakj5qoa_webpack@5.75.0
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.0.0
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
       qunit: 2.19.3
       resolve-package-path: 4.0.3
       silent-error: 1.1.1
@@ -8774,7 +8772,7 @@ packages:
     dependencies:
       '@ember/string': 3.0.1
       ember-cli-babel: 7.26.11
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8923,6 +8921,7 @@ packages:
       - '@babel/core'
       - supports-color
       - webpack
+    dev: true
 
   /ember-template-imports/3.4.1:
     resolution: {integrity: sha512-KXnBFTAVxCfXnSCUgd/iuic9ajWbmFkRUBEeorJAMqxvougsPoK22s5ygE9O3GnzYdPpMwn+8v+/NAGy8HRBGA==}
@@ -17259,21 +17258,21 @@ packages:
   /zwitch/1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
 
-  file:packages/changeset_nvoyrptyri5bht4zowzxn7dh4u:
+  file:packages/changeset_szgngu72sv6keipnf6anz4jfha:
     resolution: {directory: packages/changeset, type: directory}
     id: file:packages/changeset
     name: ember-headless-form-changeset
-    version: 0.0.0
+    version: 1.0.0-beta.0
     peerDependencies:
       ember-changeset: ^4.1.2
-      ember-headless-form: ^0.0.0
+      ember-headless-form: ^1.0.0-beta.0
       ember-source: '>=4.4.0'
       validated-changeset: ^1.3.4
     dependencies:
       '@embroider/addon-shim': 1.8.4
       ember-changeset: 4.1.2_webpack@5.75.0
       ember-headless-form: file:packages/ember-headless-form_5vzw4sbxxshw4bfzsmeoaa5v3q
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
       validated-changeset: 1.3.4
     transitivePeerDependencies:
       - supports-color
@@ -17282,7 +17281,7 @@ packages:
     resolution: {directory: packages/ember-headless-form, type: directory}
     id: file:packages/ember-headless-form
     name: ember-headless-form
-    version: 0.0.0
+    version: 1.0.0-beta.0
     peerDependencies:
       '@glimmer/component': ^1.1.2
       '@glimmer/tracking': ^1.1.2
@@ -17292,30 +17291,30 @@ packages:
       '@ember/test-waiters': 3.0.2
       '@embroider/addon-shim': 1.8.4
       '@embroider/util': 1.10.0_j4rdeqmk3bfqity5vrrnavkxem
-      '@glimmer/component': 1.1.2
+      '@glimmer/component': 1.1.2_@babel+core@7.20.12
       '@glimmer/tracking': 1.1.2
       ember-async-data: 0.7.0
       ember-modifier: 4.1.0_ember-source@4.10.0
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
       tracked-built-ins: 3.1.0
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  file:packages/yup_zbfsva7qssna2hnv7fbg4kxb2u:
+  file:packages/yup_npvmoipinnb7efewnloevbpgra:
     resolution: {directory: packages/yup, type: directory}
     id: file:packages/yup
     name: ember-headless-form-yup
-    version: 0.0.0
+    version: 1.0.0-beta.0
     peerDependencies:
-      ember-headless-form: ^0.0.0
+      ember-headless-form: ^1.0.0-beta.0
       ember-source: '>=4.4.0'
       yup: ^1.0.0
     dependencies:
       '@embroider/addon-shim': 1.8.4
       ember-functions-as-helper-polyfill: 2.1.1_ember-source@4.10.0
       ember-headless-form: file:packages/ember-headless-form_5vzw4sbxxshw4bfzsmeoaa5v3q
-      ember-source: 4.10.0_klhxxmjkcvtuhwro2kkspsfzna
+      ember-source: 4.10.0_ipwtokbwlukr3yko7oz5lbj6xy
       yup: 1.0.0
     transitivePeerDependencies:
       - supports-color

--- a/test-app/tests/integration/components/headless-form-validation-test.gts
+++ b/test-app/tests/integration/components/headless-form-validation-test.gts
@@ -2030,6 +2030,106 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
       assert.dom('[data-test-invalid]').doesNotExist();
     });
 
+    test('form yields rawErrors', async function (assert) {
+      const data: TestFormData = { firstName: 'foo' };
+
+      await render(<template>
+        <HeadlessForm
+          @data={{data}}
+          @validate={{validateFormCallbackSync}}
+          as |form|
+        >
+          {{#each-in form.rawErrors as |name errors|}}
+            <div data-test-errors={{name}}>
+              {{#each errors as |e|}}
+                <div data-test-error>
+                  <div data-test-error-type>
+                    {{e.type}}
+                  </div>
+                  <div data-test-error-value>
+                    {{e.value}}
+                  </div>
+                  <div data-test-error-message>
+                    {{e.message}}
+                  </div>
+                </div>
+              {{/each}}
+            </div>
+          {{/each-in}}
+
+          <form.Field @name="firstName" as |field|>
+            <field.Label>First Name</field.Label>
+            <field.Input data-test-first-name />
+          </form.Field>
+          <form.Field @name="lastName" as |field|>
+            <field.Label>First Name</field.Label>
+            <field.Input data-test-first-name />
+          </form.Field>
+          <button type="submit" data-test-submit>Submit</button>
+        </HeadlessForm>
+      </template>);
+
+      await click('[data-test-submit]');
+
+      // firstName
+      assert
+        .dom('[data-test-errors="firstName"] [data-test-error]')
+        .exists({ count: 2 });
+
+      assert
+        .dom(
+          '[data-test-errors="firstName"] [data-test-error]:first-child [data-test-error-type]'
+        )
+        .hasText('uppercase');
+      assert
+        .dom(
+          '[data-test-errors="firstName"] [data-test-error]:first-child [data-test-error-value]'
+        )
+        .hasText('foo');
+      assert
+        .dom(
+          '[data-test-errors="firstName"] [data-test-error]:first-child [data-test-error-message]'
+        )
+        .hasText('firstName must be upper case!');
+
+      assert
+        .dom(
+          '[data-test-errors="firstName"] [data-test-error]:last-child [data-test-error-type]'
+        )
+        .hasText('notFoo');
+      assert
+        .dom(
+          '[data-test-errors="firstName"] [data-test-error]:last-child [data-test-error-value]'
+        )
+        .hasText('foo');
+      assert
+        .dom(
+          '[data-test-errors="firstName"] [data-test-error]:last-child [data-test-error-message]'
+        )
+        .hasText('Foo is an invalid firstName!');
+
+      // lastName
+      assert
+        .dom('[data-test-errors="lastName"] [data-test-error]')
+        .exists({ count: 1 });
+
+      assert
+        .dom(
+          '[data-test-errors="lastName"] [data-test-error]:first-child [data-test-error-type]'
+        )
+        .hasText('required');
+      assert
+        .dom(
+          '[data-test-errors="lastName"] [data-test-error]:first-child [data-test-error-value]'
+        )
+        .hasNoText();
+      assert
+        .dom(
+          '[data-test-errors="lastName"] [data-test-error]:first-child [data-test-error-message]'
+        )
+        .hasText('lastName is required!');
+    });
+
     test('field yields isInvalid', async function (assert) {
       const data: TestFormData = {};
 

--- a/test-app/tests/integration/components/headless-form-validation-test.gts
+++ b/test-app/tests/integration/components/headless-form-validation-test.gts
@@ -2061,5 +2061,76 @@ module('Integration Component HeadlessForm > Validation', function (hooks) {
 
       assert.dom('[data-test-invalid]').doesNotExist();
     });
+
+    test('field yields rawErrors', async function (assert) {
+      const data: TestFormData = { firstName: 'foo' };
+
+      await render(<template>
+        <HeadlessForm
+          @data={{data}}
+          @validate={{validateFormCallbackSync}}
+          as |form|
+        >
+          <form.Field @name="firstName" as |field|>
+            <field.Label>First Name</field.Label>
+            <field.Input data-test-first-name />
+            <div data-test-first-name-errors>
+              {{#each field.rawErrors as |e|}}
+                <div data-test-error>
+                  <div data-test-error-type>
+                    {{e.type}}
+                  </div>
+                  <div data-test-error-value>
+                    {{e.value}}
+                  </div>
+                  <div data-test-error-message>
+                    {{e.message}}
+                  </div>
+                </div>
+              {{/each}}
+            </div>
+          </form.Field>
+          <button type="submit" data-test-submit>Submit</button>
+        </HeadlessForm>
+      </template>);
+
+      await click('[data-test-submit]');
+
+      assert
+        .dom('[data-test-first-name-errors] [data-test-error]')
+        .exists({ count: 2 });
+
+      assert
+        .dom(
+          '[data-test-first-name-errors] [data-test-error]:first-child [data-test-error-type]'
+        )
+        .hasText('uppercase');
+      assert
+        .dom(
+          '[data-test-first-name-errors] [data-test-error]:first-child [data-test-error-value]'
+        )
+        .hasText('foo');
+      assert
+        .dom(
+          '[data-test-first-name-errors] [data-test-error]:first-child [data-test-error-message]'
+        )
+        .hasText('firstName must be upper case!');
+
+      assert
+        .dom(
+          '[data-test-first-name-errors] [data-test-error]:last-child [data-test-error-type]'
+        )
+        .hasText('notFoo');
+      assert
+        .dom(
+          '[data-test-first-name-errors] [data-test-error]:last-child [data-test-error-value]'
+        )
+        .hasText('foo');
+      assert
+        .dom(
+          '[data-test-first-name-errors] [data-test-error]:last-child [data-test-error-message]'
+        )
+        .hasText('Foo is an invalid firstName!');
+    });
   });
 });


### PR DESCRIPTION
This closes the gap we found today when trying to wire up error rendering with ember-toucan-core. Instead of using the `<field.Errors>` component, we can now use `field.rawErrors` to get access to the array of raw `ValidationError` instances.