### PR TITLE
fix: Pin to pnpm 7.30.0 as 7.30.1 breaks tests

### DIFF
--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v2.2.4
       with:
-        version: 7
+        version: 7.30.0
     - uses: actions/setup-node@v3
       with:
         cache: 'pnpm'


### PR DESCRIPTION
I was hitting an issue in `ember-toucan-core` on `main` where we were getting what is described in https://github.com/embroider-build/embroider/issues/1378.  I ended up creating a branch here to see if `ember-headless-form` was also hitting it and sure enough it was (see: https://github.com/CrowdStrike/ember-headless-form/pull/102 - this PR was branched off of `main`).

This temporarily pins the version of `pnpm` used so that the embroider steps no longer fail as shown by https://github.com/CrowdStrike/ember-headless-form/actions/runs/4501225556/jobs/7921393859. 

We should probably file something with `pnpm` on this, or who knows, maybe it'll be resolved come Monday?

related: https://github.com/CrowdStrike/ember-toucan-core/issues/99
related 2: https://github.com/pnpm/pnpm/issues/6271