### PR TITLE
Fix changeset helper

### DIFF
--- a/.changeset/gold-tools-jump.md
+++ b/.changeset/gold-tools-jump.md
@@ -1,0 +1,9 @@
+---
+'ember-headless-form-changeset': patch
+---
+
+Fix changeset-helper to work with global resolution
+
+The previous API worked by passing the helper as-is without actually invoking it: `@validate={{validate-changeset}}`, as the expected return value of the helper is a function itself. But this does not work when globally resolving the helper by its string reference, i.e. when not using `<template>` tag or Embroider. This change fixes the API of the helper, but requires your usage to change from `@validate={{validate-changeset}}` to `@validate={{(validate-changeset)}}`, invoking it without any additional arguments.
+
+Fixes https://github.com/CrowdStrike/ember-headless-form/issues/109

--- a/docs/validation/ember-changeset-demo/demo.md
+++ b/docs/validation/ember-changeset-demo/demo.md
@@ -7,7 +7,7 @@ Using a Changeset instance to validate a form.
   @data={{changeset this.data this.validations}}
   @dataMode='mutable'
   @onSubmit={{this.handleSubmit}}
-  @validate={{validate-changeset}}
+  @validate={{(validate-changeset)}}
   as |form|
 >
   <form.Field @name='name' as |field|>

--- a/packages/changeset/src/helpers/validate-changeset.ts
+++ b/packages/changeset/src/helpers/validate-changeset.ts
@@ -11,48 +11,45 @@ import { assert } from '@ember/debug';
  * - pass this helper into the form's `@validate` hook `@validate={{validateChangeset}}`
  * - opt-in to `@dataMode="mutable"`
  */
-const validateChangeset: FormValidateCallback<EmberChangeset> = async (
-  changeset,
-  fields
-) => {
-  assert(
-    'Cannot use `validateChangeset` on `@data` that is not a Changeset instance!',
-    isChangeset(changeset)
-  );
-
-  // there is also an argument-less version of changeset.validate(), but for this to work the changeset needs a so called validationMap, and not just a validator function
-  // while ember-changeset-validations would provide such a map, we cannot necessarily rely on it being present, so the way to reliably validate all fields is to iterate
-  // over them explicitly
-  //
-  await Promise.all(fields.map((field) => changeset.validate(field)));
-
-  if (changeset.get('isValid')) {
-    return;
-  }
-
-  const errorRecord: ErrorRecord<Record<string, unknown>> = {};
-
-  for (const { key, value, validation } of changeset.get('errors')) {
-    if (!errorRecord[key]) {
-      errorRecord[key] = [];
-    }
-    const errors = errorRecord[key];
-
-    assert('Expected errorRecord to have array', errors); // TS does not understand errors cannot be undefined at this point
-
-    // some type casting due to https://github.com/validated-changeset/validated-changeset/issues/187
-    const fixedValidations = validation as string | string[];
-
-    // aggregate all errors into the ErrorRecord that is expected as the return type of the validate callback
-    const messages: string[] = Array.isArray(fixedValidations)
-      ? fixedValidations
-      : [fixedValidations];
-    errors.push(
-      ...messages.map((message) => ({ type: 'changeset', value, message }))
+export default function validateChangeset(): FormValidateCallback<EmberChangeset> {
+  return async (changeset, fields) => {
+    assert(
+      'Cannot use `validateChangeset` on `@data` that is not a Changeset instance!',
+      isChangeset(changeset)
     );
-  }
 
-  return errorRecord;
-};
+    // there is also an argument-less version of changeset.validate(), but for this to work the changeset needs a so called validationMap, and not just a validator function
+    // while ember-changeset-validations would provide such a map, we cannot necessarily rely on it being present, so the way to reliably validate all fields is to iterate
+    // over them explicitly
+    //
+    await Promise.all(fields.map((field) => changeset.validate(field)));
 
-export default validateChangeset;
+    if (changeset.get('isValid')) {
+      return;
+    }
+
+    const errorRecord: ErrorRecord<Record<string, unknown>> = {};
+
+    for (const { key, value, validation } of changeset.get('errors')) {
+      if (!errorRecord[key]) {
+        errorRecord[key] = [];
+      }
+      const errors = errorRecord[key];
+
+      assert('Expected errorRecord to have array', errors); // TS does not understand errors cannot be undefined at this point
+
+      // some type casting due to https://github.com/validated-changeset/validated-changeset/issues/187
+      const fixedValidations = validation as string | string[];
+
+      // aggregate all errors into the ErrorRecord that is expected as the return type of the validate callback
+      const messages: string[] = Array.isArray(fixedValidations)
+        ? fixedValidations
+        : [fixedValidations];
+      errors.push(
+        ...messages.map((message) => ({ type: 'changeset', value, message }))
+      );
+    }
+
+    return errorRecord;
+  };
+}

--- a/test-app/tests/integration/components/changeset-test.gts
+++ b/test-app/tests/integration/components/changeset-test.gts
@@ -59,7 +59,7 @@ module('Integration Component HeadlessForm > Changeset', function (hooks) {
         @data={{data}}
         @dataMode="mutable"
         {{! @glint-expect-error --  a type error is expected here, as this test intentionally has a type mismatch when data not being a changeset }}
-        @validate={{validateChangeset}}
+        @validate={{(validateChangeset)}}
         @onSubmit={{submitHandler}}
         as |form|
       >
@@ -83,7 +83,7 @@ module('Integration Component HeadlessForm > Changeset', function (hooks) {
       <HeadlessForm
         @data={{changeset}}
         @dataMode="mutable"
-        @validate={{validateChangeset}}
+        @validate={{(validateChangeset)}}
         @onSubmit={{submitHandler}}
         as |form|
       >
@@ -109,7 +109,7 @@ module('Integration Component HeadlessForm > Changeset', function (hooks) {
       <HeadlessForm
         @data={{changeset}}
         @dataMode="mutable"
-        @validate={{validateChangeset}}
+        @validate={{(validateChangeset)}}
         @onInvalid={{invalidHandler}}
         as |form|
       >
@@ -146,7 +146,7 @@ module('Integration Component HeadlessForm > Changeset', function (hooks) {
       <HeadlessForm
         @data={{changeset}}
         @dataMode="mutable"
-        @validate={{validateChangeset}}
+        @validate={{(validateChangeset)}}
         @onSubmit={{submitHandler}}
         as |form|
       >
@@ -180,7 +180,7 @@ module('Integration Component HeadlessForm > Changeset', function (hooks) {
       <HeadlessForm
         @data={{changeset}}
         @dataMode="mutable"
-        @validate={{validateChangeset}}
+        @validate={{(validateChangeset)}}
         as |form|
       >
         <form.Field @name="firstName" as |field|>

--- a/test-app/tests/unit/helpers/validate-changeset-test.ts
+++ b/test-app/tests/unit/helpers/validate-changeset-test.ts
@@ -26,10 +26,12 @@ module('Unit | Helpers | validate-changeset', function () {
     return errors.length > 0 ? errors : true;
   };
 
+  const validate = validateChangeset();
+
   test('it returns undefined if validation passes', async function (assert) {
     const changeset = Changeset({ firstName: 'Nicole' }, validator);
 
-    let result = await validateChangeset(changeset, ['firstName']);
+    let result = await validate(changeset, ['firstName']);
 
     assert.strictEqual(result, undefined);
   });
@@ -40,11 +42,7 @@ module('Unit | Helpers | validate-changeset', function () {
       validator
     );
 
-    let result = await validateChangeset(changeset, [
-      'firstName',
-      'lastName',
-      'email',
-    ]);
+    let result = await validate(changeset, ['firstName', 'lastName', 'email']);
 
     assert.deepEqual(result, {
       firstName: [


### PR DESCRIPTION
The previous API worked by passing the helper as-is without actually invoking it: `@validate={{validate-changeset}}`, as the expected return value of the helper is a function itself. But this does not work when globally resolving the helper by its string reference, i.e. when not using `<template>` tag or Embroider. This change fixes the API of the helper, but requires your usage to change from `@validate={{validate-changeset}}` to `@validate={{(validate-changeset)}}`, invoking it without any additional arguments.

Fixes https://github.com/CrowdStrike/ember-headless-form/issues/109