### PR TITLE
Input numbers

### DIFF
--- a/.changeset/gold-weeks-pay.md
+++ b/.changeset/gold-weeks-pay.md
@@ -1,0 +1,7 @@
+---
+'ember-headless-form': patch
+---
+
+Support numbers for Inputs with `@type="number"
+
+For `@type="number"` Inputs we support passing its value as a real number, and parse and return it as a number as well.

--- a/packages/ember-headless-form/src/-private/components/control/input.gts
+++ b/packages/ember-headless-form/src/-private/components/control/input.gts
@@ -55,7 +55,7 @@ export interface HeadlessFormControlInputComponentSignature {
     /*
      * @internal
      */
-    value: string;
+    value: string | number;
 
     /*
      * @internal
@@ -70,7 +70,7 @@ export interface HeadlessFormControlInputComponentSignature {
     /*
      * @internal
      */
-    setValue: (value: string) => void;
+    setValue: (value: string | number) => void;
 
     /*
      * @internal
@@ -106,7 +106,9 @@ export default class HeadlessFormControlInputComponent extends Component<Headles
   @action
   handleInput(e: Event | InputEvent): void {
     assert('Expected HTMLInputElement', e.target instanceof HTMLInputElement);
-    this.args.setValue(e.target.value);
+    this.args.setValue(
+      this.type === 'number' ? parseFloat(e.target.value) : e.target.value
+    );
   }
   <template>
     <input

--- a/packages/ember-headless-form/src/-private/components/field.gts
+++ b/packages/ember-headless-form/src/-private/components/field.gts
@@ -268,7 +268,7 @@ export default class HeadlessFormFieldComponent<
 
   get valueAsStringOrNumber(): string | number | undefined {
     assert(
-      `Only string values are expected for ${String(
+      `Only string or number values are expected for ${String(
         this.args.name
       )}, but you passed ${typeof this.value}`,
       typeof this.value === 'undefined' ||

--- a/packages/ember-headless-form/src/-private/components/field.gts
+++ b/packages/ember-headless-form/src/-private/components/field.gts
@@ -266,6 +266,19 @@ export default class HeadlessFormFieldComponent<
     return this.value;
   }
 
+  get valueAsStringOrNumber(): string | number | undefined {
+    assert(
+      `Only string values are expected for ${String(
+        this.args.name
+      )}, but you passed ${typeof this.value}`,
+      typeof this.value === 'undefined' ||
+        typeof this.value === 'string' ||
+        typeof this.value === 'number'
+    );
+
+    return this.value;
+  }
+
   get valueAsBoolean(): boolean | undefined {
     assert(
       `Only boolean values are expected for ${String(
@@ -298,7 +311,7 @@ export default class HeadlessFormFieldComponent<
             name=@name
             fieldId=fieldId
             errorId=errorId
-            value=this.valueAsString
+            value=this.valueAsStringOrNumber
             setValue=this.setValue
             invalid=this.hasErrors
           )

--- a/test-app/tests/integration/components/headless-form-data-test.gts
+++ b/test-app/tests/integration/components/headless-form-data-test.gts
@@ -30,6 +30,7 @@ module('Integration Component HeadlessForm > Data', function (hooks) {
         country: 'USA',
         comments: 'lorem ipsum',
         acceptTerms: true,
+        age: 21,
       };
 
       await render(<template>
@@ -58,6 +59,10 @@ module('Integration Component HeadlessForm > Data', function (hooks) {
               </group.Radio>
             </field.RadioGroup>
           </form.Field>
+          <form.Field @name="age" as |field|>
+            <field.Label>Age</field.Label>
+            <field.Input @type="number" data-test-age />
+          </form.Field>
           <form.Field @name="country" as |field|>
             <field.Label>Country</field.Label>
             <field.Select data-test-country as |select|>
@@ -81,6 +86,7 @@ module('Integration Component HeadlessForm > Data', function (hooks) {
       assert.dom('input[data-test-gender-male]').isChecked();
       assert.dom('input[data-test-gender-female]').isNotChecked();
       assert.dom('input[data-test-gender-other]').isNotChecked();
+      assert.dom('input[data-test-age]').hasValue('21');
       assert.dom('select[data-test-country]').hasValue('USA');
       assert.dom('textarea[data-test-comments]').hasValue('lorem ipsum');
       assert.dom('input[data-test-terms]').isChecked();
@@ -181,6 +187,7 @@ module('Integration Component HeadlessForm > Data', function (hooks) {
         country: 'USA',
         comments: 'lorem ipsum',
         acceptTerms: false,
+        age: 21,
       };
       const submitHandler = sinon.spy();
 
@@ -210,6 +217,10 @@ module('Integration Component HeadlessForm > Data', function (hooks) {
               </group.Radio>
             </field.RadioGroup>
           </form.Field>
+          <form.Field @name="age" as |field|>
+            <field.Label>Age</field.Label>
+            <field.Input @type="number" data-test-age />
+          </form.Field>
           <form.Field @name="country" as |field|>
             <field.Label>Country</field.Label>
             <field.Select data-test-country as |select|>
@@ -238,6 +249,7 @@ module('Integration Component HeadlessForm > Data', function (hooks) {
       await fillIn('input[data-test-last-name]', 'Chung');
       await select('select[data-test-country]', 'CA');
       await click('input[data-test-gender-female]');
+      await fillIn('input[data-test-age]', '20');
       await fillIn('textarea[data-test-comments]', 'foo bar');
       await click('input[data-test-terms]');
       await click('[data-test-submit]');
@@ -251,6 +263,7 @@ module('Integration Component HeadlessForm > Data', function (hooks) {
           country: 'USA',
           comments: 'lorem ipsum',
           acceptTerms: false,
+          age: 21,
         },
         'original data is not mutated'
       );
@@ -263,6 +276,7 @@ module('Integration Component HeadlessForm > Data', function (hooks) {
           country: 'CA',
           comments: 'foo bar',
           acceptTerms: true,
+          age: 20,
         }),
         'new data is passed to submit handler'
       );


### PR DESCRIPTION
For `@type="number"` Inputs we support passing its value as a real number, and parse and return it as a number as well (for any input, even number inputs, it's value is always a string natively).

Fixes #116 