### PR TITLE
Support reactivity when `@data` is updated

### DIFF
--- a/.changeset/six-onions-hammer.md
+++ b/.changeset/six-onions-hammer.md
@@ -1,0 +1,7 @@
+---
+'ember-headless-form': patch
+---
+
+Support reactivity when `@data` is updated
+
+This supports updates of `@data` (or any of its tracked properties) getting rendered into the form, while previously filled in ("dirty") data is being preserved. This is the implementation for case `#2` of #130.

--- a/packages/ember-headless-form/package.json
+++ b/packages/ember-headless-form/package.json
@@ -77,7 +77,6 @@
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
     "concurrently": "^8.0.0",
-    "ember-cached-decorator-polyfill": "^1.0.1",
     "ember-source": "^4.4.0",
     "ember-template-imports": "^3.4.1",
     "ember-template-lint": "^4.0.0",

--- a/packages/ember-headless-form/package.json
+++ b/packages/ember-headless-form/package.json
@@ -77,6 +77,7 @@
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
     "concurrently": "^8.0.0",
+    "ember-cached-decorator-polyfill": "^1.0.1",
     "ember-source": "^4.4.0",
     "ember-template-imports": "^3.4.1",
     "ember-template-lint": "^4.0.0",

--- a/packages/ember-headless-form/src/components/headless-form.gts
+++ b/packages/ember-headless-form/src/components/headless-form.gts
@@ -204,7 +204,7 @@ export default class HeadlessFormComponent<
   get effectiveData(): DATA {
     const obj: DATA = this.args.data ?? ({} as DATA);
 
-    if (this.args.dataMode == 'mutable') {
+    if (this.args.dataMode === 'mutable') {
       return obj;
     }
 

--- a/packages/ember-headless-form/unpublished-development-types/index.d.ts
+++ b/packages/ember-headless-form/unpublished-development-types/index.d.ts
@@ -11,3 +11,42 @@ declare module '@glint/environment-ember-loose/registry' {
     // See https://typed-ember.gitbook.io/glint/using-glint/ember/using-addons
   }
 }
+
+// copy pasted from https://github.com/ember-polyfills/ember-cached-decorator-polyfill/blob/main/index.d.ts
+// Once we are on Ember 4.12 and are using their native types instead of `types/*` packages, we can remove this!
+declare module '@glimmer/tracking' {
+  /**
+   * @decorator
+   *
+   * Memoizes the result of a getter based on autotracking.
+   *
+   * The `@cached` decorator can be used on native getters to memoize their return
+   * values based on the tracked state they consume while being calculated.
+   *
+   * By default a getter is always re-computed every time it is accessed. On
+   * average this is faster than caching every getter result by default.
+   *
+   * However, there are absolutely cases where getters are expensive, and their
+   * values are used repeatedly, so memoization would be very helpful.
+   * Strategic, opt-in memoization is a useful tool that helps developers
+   * optimize their apps when relevant, without adding extra overhead unless
+   * necessary.
+   *
+   * @example
+   *
+   * ```ts
+   * import { tracked, cached } from '@glimmer/tracking';
+   *
+   * class Person {
+   *   @tracked firstName = 'Jen';
+   *   @tracked lastName = 'Weber';
+   *
+   *   @cached
+   *   get fullName() {
+   *     return `${this.firstName} ${this.lastName}`;
+   *   }
+   * }
+   * ```
+   */
+  export let cached: PropertyDecorator;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,7 +156,7 @@ importers:
         version: 5.0.2(@babel/core@7.20.12)(@ember/string@3.0.1)(@glint/template@1.0.2)(ember-source@4.12.0)
       '@types/ember-resolver':
         specifier: ^5.0.11
-        version: 5.0.13
+        version: 5.0.13(@babel/core@7.20.12)
       '@types/ember__application':
         specifier: ^4.0.2
         version: 4.0.5(@babel/core@7.20.12)
@@ -168,22 +168,22 @@ importers:
         version: 4.0.12(@babel/core@7.20.12)
       '@types/ember__controller':
         specifier: ^4.0.1
-        version: 4.0.4
+        version: 4.0.4(@babel/core@7.20.12)
       '@types/ember__debug':
         specifier: ^4.0.1
-        version: 4.0.3
+        version: 4.0.3(@babel/core@7.20.12)
       '@types/ember__destroyable':
         specifier: ^4.0.0
         version: 4.0.1
       '@types/ember__engine':
         specifier: ^4.0.2
-        version: 4.0.4
+        version: 4.0.4(@babel/core@7.20.12)
       '@types/ember__error':
         specifier: ^4.0.0
         version: 4.0.2
       '@types/ember__object':
         specifier: ^4.0.4
-        version: 4.0.5
+        version: 4.0.5(@babel/core@7.20.12)
       '@types/ember__owner':
         specifier: ^4.0.0
         version: 4.0.3
@@ -198,7 +198,7 @@ importers:
         version: 4.0.2(@babel/core@7.20.12)
       '@types/ember__service':
         specifier: ^4.0.0
-        version: 4.0.2
+        version: 4.0.2(@babel/core@7.20.12)
       '@types/ember__string':
         specifier: ^3.0.9
         version: 3.16.3
@@ -640,9 +640,6 @@ importers:
       concurrently:
         specifier: ^8.0.0
         version: 8.0.0
-      ember-cached-decorator-polyfill:
-        specifier: ^1.0.1
-        version: 1.0.1(@babel/core@7.21.3)(ember-source@4.10.0)
       ember-source:
         specifier: ^4.4.0
         version: 4.10.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(webpack@5.75.0)
@@ -2742,6 +2739,7 @@ packages:
         optional: true
     dependencies:
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-block-scoping@7.20.11(@babel/core@7.20.12):
     resolution: {integrity: sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==}
@@ -4687,7 +4685,7 @@ packages:
       '@glint/template': 1.0.2
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4920,6 +4918,7 @@ packages:
       babel-plugin-debug-macros: 0.3.4
     transitivePeerDependencies:
       - '@babel/core'
+    dev: true
 
   /@glimmer/vm-babel-plugins@0.84.2(@babel/core@7.20.12):
     resolution: {integrity: sha512-HS2dEbJ3CgXn56wk/5QdudM7rE3vtNMvPIoG7Rrg+GhkGMNxBCIRxOeEF2g520j9rwlA2LAZFpc7MCDMFbTjNA==}
@@ -5062,8 +5061,8 @@ packages:
       '@glint/template': 1.0.2
       '@types/ember__array': 4.0.3(@babel/core@7.20.12)
       '@types/ember__component': 4.0.12(@babel/core@7.20.12)
-      '@types/ember__controller': 4.0.4
-      '@types/ember__object': 4.0.5
+      '@types/ember__controller': 4.0.4(@babel/core@7.20.12)
+      '@types/ember__object': 4.0.5(@babel/core@7.20.12)
       '@types/ember__routing': 4.0.12(@babel/core@7.20.12)
       ember-cli-htmlbars: 6.1.1
       ember-modifier: 4.1.0(ember-source@4.12.0)
@@ -5671,11 +5670,14 @@ packages:
       - webpack
     dev: true
 
-  /@types/ember-resolver@5.0.13:
+  /@types/ember-resolver@5.0.13(@babel/core@7.20.12):
     resolution: {integrity: sha512-pO964cAPhAaFJoS28M8+b5MzAhQ/tVuNM4GDUIAexheQat36axG2WTG8LQ5ea07MSFPesrRFk2T3z88pfvdYKA==}
     dependencies:
-      '@types/ember__object': 4.0.5
+      '@types/ember__object': 4.0.5(@babel/core@7.20.12)
       '@types/ember__owner': 4.0.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
     dev: true
 
   /@types/ember-resolver@9.0.0(@ember/string@3.0.1)(ember-source@4.12.0):
@@ -7306,6 +7308,7 @@ packages:
         optional: true
     dependencies:
       semver: 5.7.1
+    dev: true
 
   /babel-plugin-debug-macros@0.3.4(@babel/core@7.20.12):
     resolution: {integrity: sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==}
@@ -10001,19 +10004,6 @@ packages:
       - supports-color
     dev: false
 
-  /ember-cache-primitive-polyfill@1.0.1(@babel/core@7.21.3):
-    resolution: {integrity: sha512-hSPcvIKarA8wad2/b6jDd/eU+OtKmi6uP+iYQbzi5TQpjsqV6b4QdRqrLk7ClSRRKBAtdTuutx+m+X+WlEd2lw==}
-    engines: {node: 10.* || >= 12}
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-version-checker: 5.1.2
-      ember-compatibility-helpers: 1.2.6(@babel/core@7.21.3)
-      silent-error: 1.1.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-    dev: true
-
   /ember-cached-decorator-polyfill@1.0.1(@babel/core@7.20.12)(ember-source@4.12.0):
     resolution: {integrity: sha512-VDgrpIJ6rDDHIfkYrsFR1BM3fpcC0+zFWIOsX0qY44zPrIXjhQWVXs2iVXLIPHprSgf+tFQ3ESxwDscpeRe/0A==}
     engines: {node: 14.* || >= 16}
@@ -10031,24 +10021,6 @@ packages:
       - '@babel/core'
       - supports-color
     dev: false
-
-  /ember-cached-decorator-polyfill@1.0.1(@babel/core@7.21.3)(ember-source@4.10.0):
-    resolution: {integrity: sha512-VDgrpIJ6rDDHIfkYrsFR1BM3fpcC0+zFWIOsX0qY44zPrIXjhQWVXs2iVXLIPHprSgf+tFQ3ESxwDscpeRe/0A==}
-    engines: {node: 14.* || >= 16}
-    peerDependencies:
-      ember-source: ^3.13.0 || ^4.0.0
-    dependencies:
-      '@embroider/macros': 1.10.0
-      '@glimmer/tracking': 1.1.2
-      babel-import-util: 1.3.0
-      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.21.3)
-      ember-cli-babel: 7.26.11
-      ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 4.10.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(webpack@5.75.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-    dev: true
 
   /ember-changeset-validations@4.1.1(webpack@5.75.0):
     resolution: {integrity: sha512-lRT+LOwY+kTMRC/op85L6+FFHDuOkoQvqgexexTiLFECiTNw4vQbOrcAqhfe6n/QJBr5uypZ+bg4W1Ng34dkMg==}
@@ -10089,7 +10061,7 @@ packages:
       ember-source: ^3.28.0 || ^4.0.0
     dependencies:
       ember-cli-babel: 7.26.11
-      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
       git-repo-info: 2.1.1
     transitivePeerDependencies:
       - supports-color
@@ -10808,7 +10780,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10838,14 +10810,14 @@ packages:
       ember-source: '>=3.28'
       qunit: ^2.13.0
     dependencies:
-      '@ember/test-helpers': 2.9.3(@glint/template@1.0.2)(ember-source@4.12.0)
+      '@ember/test-helpers': 2.9.3(@babel/core@7.20.12)(@glint/template@1.0.2)(ember-source@4.12.0)
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
       ember-auto-import: 2.6.1(patch_hash=ic4j24wybap2f2xedeoakj5qoa)(webpack@5.75.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.0.0
-      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
       qunit: 2.19.3
       resolve-package-path: 4.0.3
       silent-error: 1.1.1
@@ -10867,7 +10839,7 @@ packages:
     dependencies:
       '@ember/string': 3.0.1
       ember-cli-babel: 7.26.11
-      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11057,6 +11029,7 @@ packages:
       - '@babel/core'
       - supports-color
       - webpack
+    dev: true
 
   /ember-template-imports@3.4.1:
     resolution: {integrity: sha512-KXnBFTAVxCfXnSCUgd/iuic9ajWbmFkRUBEeorJAMqxvougsPoK22s5ygE9O3GnzYdPpMwn+8v+/NAGy8HRBGA==}
@@ -19519,7 +19492,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-changeset: 4.1.2(webpack@5.75.0)
       ember-headless-form: file:packages/ember-headless-form(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.12.0)
-      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
       validated-changeset: 1.3.4
     transitivePeerDependencies:
       - supports-color
@@ -19537,11 +19510,11 @@ packages:
       '@babel/runtime': 7.20.7
       '@embroider/addon-shim': 1.8.4
       '@embroider/util': 1.10.0(@glint/template@1.0.2)(ember-source@4.12.0)
-      '@glimmer/component': 1.1.2
+      '@glimmer/component': 1.1.2(@babel/core@7.20.12)
       '@glimmer/tracking': 1.1.2
       ember-async-data: 0.7.0
       ember-modifier: 4.1.0(ember-source@4.12.0)
-      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
       tracked-built-ins: 3.1.0
     transitivePeerDependencies:
       - '@glint/template'
@@ -19560,7 +19533,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-functions-as-helper-polyfill: 2.1.1(ember-source@4.12.0)
       ember-headless-form: file:packages/ember-headless-form(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.12.0)
-      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
       yup: 1.0.0
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,7 +156,7 @@ importers:
         version: 5.0.2(@babel/core@7.20.12)(@ember/string@3.0.1)(@glint/template@1.0.2)(ember-source@4.12.0)
       '@types/ember-resolver':
         specifier: ^5.0.11
-        version: 5.0.13(@babel/core@7.20.12)
+        version: 5.0.13
       '@types/ember__application':
         specifier: ^4.0.2
         version: 4.0.5(@babel/core@7.20.12)
@@ -168,22 +168,22 @@ importers:
         version: 4.0.12(@babel/core@7.20.12)
       '@types/ember__controller':
         specifier: ^4.0.1
-        version: 4.0.4(@babel/core@7.20.12)
+        version: 4.0.4
       '@types/ember__debug':
         specifier: ^4.0.1
-        version: 4.0.3(@babel/core@7.20.12)
+        version: 4.0.3
       '@types/ember__destroyable':
         specifier: ^4.0.0
         version: 4.0.1
       '@types/ember__engine':
         specifier: ^4.0.2
-        version: 4.0.4(@babel/core@7.20.12)
+        version: 4.0.4
       '@types/ember__error':
         specifier: ^4.0.0
         version: 4.0.2
       '@types/ember__object':
         specifier: ^4.0.4
-        version: 4.0.5(@babel/core@7.20.12)
+        version: 4.0.5
       '@types/ember__owner':
         specifier: ^4.0.0
         version: 4.0.3
@@ -198,7 +198,7 @@ importers:
         version: 4.0.2(@babel/core@7.20.12)
       '@types/ember__service':
         specifier: ^4.0.0
-        version: 4.0.2(@babel/core@7.20.12)
+        version: 4.0.2
       '@types/ember__string':
         specifier: ^3.0.9
         version: 3.16.3
@@ -640,6 +640,9 @@ importers:
       concurrently:
         specifier: ^8.0.0
         version: 8.0.0
+      ember-cached-decorator-polyfill:
+        specifier: ^1.0.1
+        version: 1.0.1(@babel/core@7.21.3)(ember-source@4.10.0)
       ember-source:
         specifier: ^4.4.0
         version: 4.10.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(webpack@5.75.0)
@@ -742,19 +745,19 @@ importers:
         version: 4.0.12(@babel/core@7.20.12)
       '@types/ember__controller':
         specifier: ^4.0.0
-        version: 4.0.4
+        version: 4.0.4(@babel/core@7.20.12)
       '@types/ember__debug':
         specifier: ^4.0.0
-        version: 4.0.3
+        version: 4.0.3(@babel/core@7.20.12)
       '@types/ember__engine':
         specifier: ^4.0.0
-        version: 4.0.4
+        version: 4.0.4(@babel/core@7.20.12)
       '@types/ember__error':
         specifier: ^4.0.0
         version: 4.0.2
       '@types/ember__object':
         specifier: ^4.0.0
-        version: 4.0.5
+        version: 4.0.5(@babel/core@7.20.12)
       '@types/ember__polyfills':
         specifier: ^4.0.0
         version: 4.0.1
@@ -766,7 +769,7 @@ importers:
         version: 4.0.2(@babel/core@7.20.12)
       '@types/ember__service':
         specifier: ^4.0.0
-        version: 4.0.2
+        version: 4.0.2(@babel/core@7.20.12)
       '@types/ember__string':
         specifier: ^3.16.0
         version: 3.16.3
@@ -2739,7 +2742,6 @@ packages:
         optional: true
     dependencies:
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-block-scoping@7.20.11(@babel/core@7.20.12):
     resolution: {integrity: sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==}
@@ -4685,7 +4687,7 @@ packages:
       '@glint/template': 1.0.2
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4918,7 +4920,6 @@ packages:
       babel-plugin-debug-macros: 0.3.4
     transitivePeerDependencies:
       - '@babel/core'
-    dev: true
 
   /@glimmer/vm-babel-plugins@0.84.2(@babel/core@7.20.12):
     resolution: {integrity: sha512-HS2dEbJ3CgXn56wk/5QdudM7rE3vtNMvPIoG7Rrg+GhkGMNxBCIRxOeEF2g520j9rwlA2LAZFpc7MCDMFbTjNA==}
@@ -5061,8 +5062,8 @@ packages:
       '@glint/template': 1.0.2
       '@types/ember__array': 4.0.3(@babel/core@7.20.12)
       '@types/ember__component': 4.0.12(@babel/core@7.20.12)
-      '@types/ember__controller': 4.0.4(@babel/core@7.20.12)
-      '@types/ember__object': 4.0.5(@babel/core@7.20.12)
+      '@types/ember__controller': 4.0.4
+      '@types/ember__object': 4.0.5
       '@types/ember__routing': 4.0.12(@babel/core@7.20.12)
       ember-cli-htmlbars: 6.1.1
       ember-modifier: 4.1.0(ember-source@4.12.0)
@@ -5670,14 +5671,11 @@ packages:
       - webpack
     dev: true
 
-  /@types/ember-resolver@5.0.13(@babel/core@7.20.12):
+  /@types/ember-resolver@5.0.13:
     resolution: {integrity: sha512-pO964cAPhAaFJoS28M8+b5MzAhQ/tVuNM4GDUIAexheQat36axG2WTG8LQ5ea07MSFPesrRFk2T3z88pfvdYKA==}
     dependencies:
-      '@types/ember__object': 4.0.5(@babel/core@7.20.12)
+      '@types/ember__object': 4.0.5
       '@types/ember__owner': 4.0.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
     dev: true
 
   /@types/ember-resolver@9.0.0(@ember/string@3.0.1)(ember-source@4.12.0):
@@ -7308,7 +7306,6 @@ packages:
         optional: true
     dependencies:
       semver: 5.7.1
-    dev: true
 
   /babel-plugin-debug-macros@0.3.4(@babel/core@7.20.12):
     resolution: {integrity: sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==}
@@ -10004,6 +10001,19 @@ packages:
       - supports-color
     dev: false
 
+  /ember-cache-primitive-polyfill@1.0.1(@babel/core@7.21.3):
+    resolution: {integrity: sha512-hSPcvIKarA8wad2/b6jDd/eU+OtKmi6uP+iYQbzi5TQpjsqV6b4QdRqrLk7ClSRRKBAtdTuutx+m+X+WlEd2lw==}
+    engines: {node: 10.* || >= 12}
+    dependencies:
+      ember-cli-babel: 7.26.11
+      ember-cli-version-checker: 5.1.2
+      ember-compatibility-helpers: 1.2.6(@babel/core@7.21.3)
+      silent-error: 1.1.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: true
+
   /ember-cached-decorator-polyfill@1.0.1(@babel/core@7.20.12)(ember-source@4.12.0):
     resolution: {integrity: sha512-VDgrpIJ6rDDHIfkYrsFR1BM3fpcC0+zFWIOsX0qY44zPrIXjhQWVXs2iVXLIPHprSgf+tFQ3ESxwDscpeRe/0A==}
     engines: {node: 14.* || >= 16}
@@ -10021,6 +10031,24 @@ packages:
       - '@babel/core'
       - supports-color
     dev: false
+
+  /ember-cached-decorator-polyfill@1.0.1(@babel/core@7.21.3)(ember-source@4.10.0):
+    resolution: {integrity: sha512-VDgrpIJ6rDDHIfkYrsFR1BM3fpcC0+zFWIOsX0qY44zPrIXjhQWVXs2iVXLIPHprSgf+tFQ3ESxwDscpeRe/0A==}
+    engines: {node: 14.* || >= 16}
+    peerDependencies:
+      ember-source: ^3.13.0 || ^4.0.0
+    dependencies:
+      '@embroider/macros': 1.10.0
+      '@glimmer/tracking': 1.1.2
+      babel-import-util: 1.3.0
+      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.21.3)
+      ember-cli-babel: 7.26.11
+      ember-cli-babel-plugin-helpers: 1.1.1
+      ember-source: 4.10.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(webpack@5.75.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: true
 
   /ember-changeset-validations@4.1.1(webpack@5.75.0):
     resolution: {integrity: sha512-lRT+LOwY+kTMRC/op85L6+FFHDuOkoQvqgexexTiLFECiTNw4vQbOrcAqhfe6n/QJBr5uypZ+bg4W1Ng34dkMg==}
@@ -10061,7 +10089,7 @@ packages:
       ember-source: ^3.28.0 || ^4.0.0
     dependencies:
       ember-cli-babel: 7.26.11
-      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
       git-repo-info: 2.1.1
     transitivePeerDependencies:
       - supports-color
@@ -10780,7 +10808,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10810,14 +10838,14 @@ packages:
       ember-source: '>=3.28'
       qunit: ^2.13.0
     dependencies:
-      '@ember/test-helpers': 2.9.3(@babel/core@7.20.12)(@glint/template@1.0.2)(ember-source@4.12.0)
+      '@ember/test-helpers': 2.9.3(@glint/template@1.0.2)(ember-source@4.12.0)
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
       ember-auto-import: 2.6.1(patch_hash=ic4j24wybap2f2xedeoakj5qoa)(webpack@5.75.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.0.0
-      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
       qunit: 2.19.3
       resolve-package-path: 4.0.3
       silent-error: 1.1.1
@@ -10839,7 +10867,7 @@ packages:
     dependencies:
       '@ember/string': 3.0.1
       ember-cli-babel: 7.26.11
-      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11029,7 +11057,6 @@ packages:
       - '@babel/core'
       - supports-color
       - webpack
-    dev: true
 
   /ember-template-imports@3.4.1:
     resolution: {integrity: sha512-KXnBFTAVxCfXnSCUgd/iuic9ajWbmFkRUBEeorJAMqxvougsPoK22s5ygE9O3GnzYdPpMwn+8v+/NAGy8HRBGA==}
@@ -19492,7 +19519,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-changeset: 4.1.2(webpack@5.75.0)
       ember-headless-form: file:packages/ember-headless-form(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.12.0)
-      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
       validated-changeset: 1.3.4
     transitivePeerDependencies:
       - supports-color
@@ -19510,11 +19537,11 @@ packages:
       '@babel/runtime': 7.20.7
       '@embroider/addon-shim': 1.8.4
       '@embroider/util': 1.10.0(@glint/template@1.0.2)(ember-source@4.12.0)
-      '@glimmer/component': 1.1.2(@babel/core@7.20.12)
+      '@glimmer/component': 1.1.2
       '@glimmer/tracking': 1.1.2
       ember-async-data: 0.7.0
       ember-modifier: 4.1.0(ember-source@4.12.0)
-      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
       tracked-built-ins: 3.1.0
     transitivePeerDependencies:
       - '@glint/template'
@@ -19533,7 +19560,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-functions-as-helper-polyfill: 2.1.1(ember-source@4.12.0)
       ember-headless-form: file:packages/ember-headless-form(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.12.0)
-      ember-source: 4.12.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@glimmer/component@1.1.2)(webpack@5.75.0)
       yup: 1.0.0
     transitivePeerDependencies:
       - supports-color

--- a/test-app/tests/integration/components/headless-form-data-test.gts
+++ b/test-app/tests/integration/components/headless-form-data-test.gts
@@ -12,7 +12,7 @@ import {
   select,
   triggerEvent,
 } from '@ember/test-helpers';
-import { module, skip, test } from 'qunit';
+import { module, test } from 'qunit';
 
 import { HeadlessForm } from 'ember-headless-form';
 import sinon from 'sinon';

--- a/test-app/tests/integration/components/headless-form-data-test.gts
+++ b/test-app/tests/integration/components/headless-form-data-test.gts
@@ -110,7 +110,43 @@ module('Integration Component HeadlessForm > Data', function (hooks) {
       assert.dom('[data-test-last-name]').hasText('Ward');
     });
 
-    skip('form controls are reactive to data updates', async function (assert) {
+    test('form controls are reactive to updating data', async function (assert) {
+      interface Data {
+        firstName: string;
+        lastName: string;
+      }
+      class Context {
+        @tracked
+        data?: Data;
+      }
+      const ctx = new Context();
+      ctx.data = { firstName: 'Tony', lastName: 'Ward' };
+
+      await render(<template>
+        <HeadlessForm @data={{ctx.data}} as |form|>
+          <form.Field @name="firstName" as |field|>
+            <field.Label>First Name</field.Label>
+            <field.Input data-test-first-name />
+          </form.Field>
+          <form.Field @name="lastName" as |field|>
+            <field.Label>Last Name</field.Label>
+            <field.Input data-test-last-name />
+          </form.Field>
+        </HeadlessForm>
+      </template>);
+
+      assert.dom('input[data-test-first-name]').hasValue('Tony');
+      assert.dom('input[data-test-last-name]').hasValue('Ward');
+
+      ctx.data = { firstName: 'Preston', lastName: 'Sego' };
+
+      await rerender();
+
+      assert.dom('input[data-test-first-name]').hasValue('Preston');
+      assert.dom('input[data-test-last-name]').hasValue('Sego');
+    });
+
+    test('form controls are reactive to updating data properties', async function (assert) {
       class DummyData {
         @tracked
         firstName = 'Tony';
@@ -142,6 +178,43 @@ module('Integration Component HeadlessForm > Data', function (hooks) {
       await rerender();
 
       assert.dom('input[data-test-first-name]').hasValue('Preston');
+      assert.dom('input[data-test-last-name]').hasValue('Sego');
+    });
+
+    test('form controls keep dirty state when updating data properties', async function (assert) {
+      class DummyData {
+        @tracked
+        firstName = 'Tony';
+
+        @tracked
+        lastName = 'Ward';
+      }
+      const data = new DummyData();
+
+      await render(<template>
+        <HeadlessForm @data={{data}} as |form|>
+          <form.Field @name="firstName" as |field|>
+            <field.Label>First Name</field.Label>
+            <field.Input data-test-first-name />
+          </form.Field>
+          <form.Field @name="lastName" as |field|>
+            <field.Label>Last Name</field.Label>
+            <field.Input data-test-last-name />
+          </form.Field>
+        </HeadlessForm>
+      </template>);
+
+      assert.dom('input[data-test-first-name]').hasValue('Tony');
+      assert.dom('input[data-test-last-name]').hasValue('Ward');
+
+      await fillIn('input[data-test-first-name]', 'Simon');
+
+      data.firstName = 'Preston';
+      data.lastName = 'Sego';
+
+      await rerender();
+
+      assert.dom('input[data-test-first-name]').hasValue('Simon');
       assert.dom('input[data-test-last-name]').hasValue('Sego');
     });
 


### PR DESCRIPTION
This supports updates of `@data` (or any of its tracked properties) getting rendered into the form, while previously filled in ("dirty") data is being preserved. This is the implementation for case `#2` of #130.

Will add some sections to the docs when #117 is also tackled, as these features are related.