### PR TITLE
Try to fix publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: ./.github/actions/pnpm
-      - run: pnpm build
+      - run: pnpm build:packages
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start:docs-app": "pnpm --filter './packages/*' build; pnpm --stream --parallel --filter docs-app... start",
     "start:test-app": "pnpm --filter './packages/*' build; pnpm --stream --parallel --filter test-app... start",
     "build": "pnpm turbo build",
+    "build:packages": "pnpm turbo --filter='./packages/*' build",
     "test": "pnpm turbo --filter test-app test",
     "test:docs": "pnpm turbo --filter docs-app test",
     "lint": "pnpm turbo lint",

--- a/packages/changeset/package.json
+++ b/packages/changeset/package.json
@@ -22,8 +22,7 @@
     "lint:js:fix": "eslint . --fix",
     "lint:types": "glint",
     "start": "rollup --config --watch",
-    "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
-    "prepack": "rollup --config"
+    "test": "echo 'A v2 addon does not have tests, run tests in test-app'"
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.0.0"

--- a/packages/ember-headless-form/package.json
+++ b/packages/ember-headless-form/package.json
@@ -24,8 +24,7 @@
     "lint:prettier": "prettier -c .",
     "lint:prettier:fix": "prettier -w .",
     "start": "rollup --config --watch",
-    "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
-    "prepack": "rollup --config"
+    "test": "echo 'A v2 addon does not have tests, run tests in test-app'"
   },
   "dependencies": {
     "@babel/runtime": "^7.20.7",

--- a/packages/yup/package.json
+++ b/packages/yup/package.json
@@ -22,8 +22,7 @@
     "lint:js:fix": "eslint . --fix",
     "lint:types": "glint",
     "start": "rollup --config --watch",
-    "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
-    "prepack": "rollup --config"
+    "test": "echo 'A v2 addon does not have tests, run tests in test-app'"
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.0.0",


### PR DESCRIPTION
* adds a `build:packages` script that only builds the packages that we want to publish. previously it would also needlessly do prod builds of test-app and docs-app
* remove the `prepack` script, as we only publish from CI and do an explicit build there anyway

Hopefully that could fix the release failure, as this was likely happening when running `prepack` (as part of `npm publish`). That's what I am assuming at least...