### PR TITLE
Increase renovate's prConcurrentLimit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,7 @@
   // bump for apps
   // update-lockfile for addons/libraries
   "rangeStrategy": "update-lockfile",
+  "prConcurrentLimit": 20,
   // From the docs:
   // https://docs.renovatebot.com/configuration-options/#packagerules
   // Important to know: Renovate will evaluate all packageRules and not stop once it gets a first match.


### PR DESCRIPTION
By default, we only allow 10 concurrent PRs. If some PRs are red and not trivial to fix, and new updates are only created once a week (see `"schedule": ["after 9pm on sunday"]`), then this can easily lead to a larger backlog, see #87