### PR TITLE
Remove optional chaining in assert() call to workaround bug

### DIFF
--- a/.changeset/spotty-pigs-exercise.md
+++ b/.changeset/spotty-pigs-exercise.md
@@ -1,0 +1,5 @@
+---
+"ember-headless-form": patch
+---
+
+Remove optional chaining in `assert()`  call to workaround [upstream bug](https://github.com/ember-cli/babel-plugin-debug-macros/issues/89)

--- a/packages/ember-headless-form/src/components/headless-form.gts
+++ b/packages/ember-headless-form/src/components/headless-form.gts
@@ -465,7 +465,8 @@ export default class HeadlessFormComponent<
     } else {
       assert(
         'Validation errors expected to be present. If you see this, please report it as a bug to ember-headless-form!',
-        this.validationState?.isResolved
+        // Do *not* use optional chaining due to https://github.com/ember-cli/babel-plugin-debug-macros/issues/89
+        this.validationState && this.validationState.isResolved
       );
       this.args.onInvalid?.(this.effectiveData, this.validationState.value);
     }


### PR DESCRIPTION
Reported this earlier: https://github.com/ember-cli/babel-plugin-debug-macros/issues/89, and forgot about it! 😅 

This is removing the usage, which just bit us in our monorepo.