### PR TITLE
Use corepack instead of volta

### DIFF
--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -4,8 +4,6 @@ runs:
   using: 'composite'
   steps:
     - uses: pnpm/action-setup@v4.0.0
-      with:
-        version: 8.6.5
     - uses: actions/setup-node@v4
       with:
         cache: 'pnpm'

--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -144,8 +144,5 @@
     "ember-headless-form-yup": {
       "injected": true
     }
-  },
-  "volta": {
-    "extends": "../package.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,8 +49,5 @@
       "ember-auto-import@2.6.1": "patches/ember-auto-import@2.6.1.patch"
     }
   },
-  "volta": {
-    "node": "20.15.1",
-    "pnpm": "8.15.8"
-  }
+  "packageManager": "pnpm@8.15.8+sha256.691fe176eea9a8a80df20e4976f3dfb44a04841ceb885638fe2a26174f81e65e"
 }

--- a/packages/changeset/package.json
+++ b/packages/changeset/package.json
@@ -110,8 +110,5 @@
         "dist/*"
       ]
     }
-  },
-  "volta": {
-    "extends": "../../package.json"
   }
 }

--- a/packages/ember-headless-form/package.json
+++ b/packages/ember-headless-form/package.json
@@ -121,8 +121,5 @@
         "dist/*"
       ]
     }
-  },
-  "volta": {
-    "extends": "../../package.json"
   }
 }

--- a/packages/yup/package.json
+++ b/packages/yup/package.json
@@ -109,8 +109,5 @@
         "dist/*"
       ]
     }
-  },
-  "volta": {
-    "extends": "../../package.json"
   }
 }

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -138,8 +138,5 @@
   },
   "ember": {
     "edition": "octane"
-  },
-  "volta": {
-    "extends": "../package.json"
   }
 }


### PR DESCRIPTION
Having corepack enabled locally and volta in use is messing things up, so switching to just corepack.

@kellyselden @Exelord  I remember some discussion around this... this is the way to go for now, is it? We don't have a good and solid way to let volta manage the node version and corepack the package manager, do we?